### PR TITLE
chore: bump joxit/docker-registry-ui from 2.5.2 to 2.5.7

### DIFF
--- a/charts/registry-ui/Chart.yaml
+++ b/charts/registry-ui/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: The simplest and most complete UI for your private registry
 name: registry-ui
-version: 0.0.16
+version: 0.0.17
 dependencies:
   - name: docker-registry-ui
     version: 1.1.3

--- a/charts/registry-ui/values.yaml
+++ b/charts/registry-ui/values.yaml
@@ -1,5 +1,6 @@
 docker-registry-ui:
   ui:
+    image: joxit/docker-registry-ui:2.5.7
     title: "CHORUS OCI registry"
     dockerRegistryUrl: "https://registry.build.chorus-tre.local"
     registrySecured: false


### PR DESCRIPTION
The default one is slightly outdated.

https://github.com/Joxit/helm-charts/blob/c59119b655a704e07733f40103d47a96c5878f32/charts/docker-registry-ui/values.yaml#L92