### PR TITLE
chore: bump bitnami/sealed-secret from 2.15.0 to 2.15.4

### DIFF
--- a/charts/sealed-secrets/Chart.lock
+++ b/charts/sealed-secrets/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: sealed-secrets
   repository: https://bitnami-labs.github.io/sealed-secrets
-  version: 2.15.3
-digest: sha256:b7dda9bc7e2db4c9ec3ee453a610c1dfd108ed90e1d906f4ca9167460b77d1f9
-generated: "2024-05-14T08:53:04.212526+02:00"
+  version: 2.15.4
+digest: sha256:d23b4ff465bb2d288d452fbc7f34468b995f992de2f25638811ba116b8963401
+generated: "2024-06-05T09:55:32.170515+02:00"

--- a/charts/sealed-secrets/Chart.yaml
+++ b/charts/sealed-secrets/Chart.yaml
@@ -4,5 +4,5 @@ name: sealed-secrets
 version: 0.0.2
 dependencies:
   - name: sealed-secrets
-    version: 2.15.3
+    version: 2.15.4
     repository: https://bitnami-labs.github.io/sealed-secrets


### PR DESCRIPTION
There is a CVE in the lower version, see https://github.com/bitnami-labs/sealed-secrets/blob/main/RELEASE-NOTES.md#v0262