### PR TITLE
chore: bump ArgoCD from 6.7.15 to 7.1.1

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -36,6 +36,7 @@ kubectl wait pod \
     --timeout=60s
 
 # install argocd
+kubectl apply -k "https://github.com/argoproj/argo-cd/manifests/crds?ref=v2.11.2"
 helm dep update charts/argo-cd
 kubectl get namespace | grep -q "^argocd " || kubectl create namespace argocd
 helm install chorus-build-argo-cd charts/argo-cd -n argocd --set argo-cd.global.domain=argo-cd.build.$DOMAIN_NAME --set argo-cd.server.ingress.extraTls[0].hosts[0]=argo-cd.build.$DOMAIN_NAME --set argo-cd.server.ingress.extraTls[0].secretName=argocd-ingress-http --set argo-cd.server.ingressGrpc.extraTls[0].hosts[0]=grpc.argo-cd.build.$DOMAIN_NAME --set argo-cd.server.ingressGrpc.extraTls[0].secretName=argocd-ingress-grpc

--- a/charts/argo-cd/Chart.lock
+++ b/charts/argo-cd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: argo-cd
   repository: https://argoproj.github.io/argo-helm
-  version: 6.7.15
-digest: sha256:b8e229cbe4140cf1eeb1fc028fbd0406476cd929e018321cf50a5683ad28a1de
-generated: "2024-04-26T11:08:16.333695+02:00"
+  version: 7.1.1
+digest: sha256:d76271686434b9d30757d36c6df0e2f87a9c7789f2c35dabf3a41e902a3e2f80
+generated: "2024-06-05T11:14:45.046864+02:00"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 0.0.8
+version: 0.0.9
 dependencies:
   - name: argo-cd
-    version: 6.7.15
+    version: 7.1.1
     repository: https://argoproj.github.io/argo-helm

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1,4 +1,6 @@
 argo-cd:
+  crds:
+    install: false
   global:
     domain: argo-cd.build.chorus-tre.local
   configs:


### PR DESCRIPTION
The CRDs cannot be managed by Helm (by design) so, let's move them to the bootstrap.