### PR TITLE
feat(ci): build and push images

### DIFF
--- a/ci/build-images-sensor.yaml
+++ b/ci/build-images-sensor.yaml
@@ -121,9 +121,8 @@ spec:
                             do sleep 3;
                           done;
 
-                          cd "{{inputs.parameters.path}}";
                           exec ./build.sh
-                      workingDir: /src
+                      workingDir: /src/{{inputs.parameters.path}}
                     sidecars:
                       - name: dind
                         image: docker:26-dind


### PR DESCRIPTION
Goes hand and hand with https://github.com/CHORUS-TRE/images/pull/3

~~What's missing is the authentication step to the registry. Hence the draft mode.~~

~~https://docs.gitlab.com/ee/ci/docker/authenticate_registry.html~~ no auth yet 🚀 

DSDIP-420

Is it luck? https://argo-workflows.readthedocs.io/en/latest/walk-through/docker-in-docker-using-sidecars/