### PR TITLE
chore(ci): bump OCI Charts releaser to 0.1.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -25,7 +25,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
-        uses: bitdeps/helm-oci-charts-releaser@v0.1.0
+        uses: bitdeps/helm-oci-charts-releaser@v0.1.2
         with:
             oci_registry: registry.build.chorus-tre.ch
             oci_username: admin


### PR DESCRIPTION
https://github.com/bitdeps/helm-oci-charts-releaser/releases/tag/v0.1.2