### PR TITLE
chore: bump argo-workflows from 0.41.2 to 0.41.11

### DIFF
--- a/charts/argo-workflows/Chart.lock
+++ b/charts/argo-workflows/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: argo-workflows
+  repository: https://argoproj.github.io/argo-helm
+  version: 0.41.11
+digest: sha256:17262d7ae0bf7dabb7480a912b93c75b2c6028705313c4fb97f45bfffd624aa7
+generated: "2024-06-20T16:01:47.275097+02:00"

--- a/charts/argo-workflows/Chart.yaml
+++ b/charts/argo-workflows/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: A Helm chart for Argo Workflows 
 name: argo-workflows
-version: 0.0.8
+version: 0.0.9
 dependencies:
   - name: argo-workflows
-    version: 0.41.2
+    version: 0.41.11
     repository: https://argoproj.github.io/argo-helm


### PR DESCRIPTION
Using argo-workflows 3.5.8 (was 3.5.6)