### PR TITLE
chore(charts): bump argo-cd from 7.1.4 to 7.2.1

### DIFF
--- a/charts/argo-cd/Chart.lock
+++ b/charts/argo-cd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: argo-cd
   repository: https://argoproj.github.io/argo-helm
-  version: 7.1.4
-digest: sha256:f7856d80918eb479c9d15d7bb964039ed8a06029cff09de1a0554299ccf81781
-generated: "2024-06-18T16:02:03.239394+02:00"
+  version: 7.2.1
+digest: sha256:1e134760a6b90ce1ba197ee0a78d7b03fd2cf8bfe63b9275b3a7ae817e5ca836
+generated: "2024-06-24T09:27:25.012153+02:00"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 name: argo-cd
-version: 0.0.10
+version: 0.0.11
 dependencies:
   - name: argo-cd
-    version: 7.1.4
+    version: 7.2.1
     repository: https://argoproj.github.io/argo-helm


### PR DESCRIPTION
Smole changes

## 7.2.1 - 2024-06-21

### Changed

- Default argocd repo-server init container replicas to empty

## 7.2.0 - 2024-06-20

### Removed

- Remove server.certificate.secretName, as the expected secret name is static (argocd-server-tls)
- Remove applicationSet.certificate.secretName, as the expected secret name is static (argocd-applicationset-controller-tls)

## 7.1.5 - 2024-06-19

### Added

- Added secrettemplateAnnotation field for argocd server certificate
