### PR TITLE
fix(regsitry): needed to pull the new image

### DIFF
--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -20,7 +20,7 @@ serviceAccount:
 image:
   repository: registry
   tag: 2.8.3
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 # imagePullSecrets:
     # - name: docker
 service:


### PR DESCRIPTION
Set the pull policy to `Always` to set the new image.

We can get rid of this hacked chart when we have Harbor.