### PR TITLE
fix(argo-ci): chart version was not updated

### DIFF
--- a/charts/argo-ci/Chart.yaml
+++ b/charts/argo-ci/Chart.yaml
@@ -20,4 +20,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.47
+version: 0.0.48


### PR DESCRIPTION
Webhook is 404 because new path does not exist as chart version was not updated