### PR TITLE
fix(argo-ci): port should be a string

### DIFF
--- a/charts/argo-ci/Chart.yaml
+++ b/charts/argo-ci/Chart.yaml
@@ -20,4 +20,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.49
+version: 0.0.50

--- a/charts/argo-ci/templates/github-eventsource.yaml
+++ b/charts/argo-ci/templates/github-eventsource.yaml
@@ -21,7 +21,7 @@ spec:
         # endpoint to listen to events on
         endpoint: /push-{{ .name }}
         # port to run internal HTTP server on
-        port: {{ $targetPort }}
+        port: "{{ $targetPort }}"
         # HTTP request method to allow. In this case, only POST requests are accepted
         method: POST
         # url the event-source will use to register at Github.


### PR DESCRIPTION
https://argo-workflows.build.chorus-tre.ch/event-sources/argo
`{"code":13,"message":"json: cannot unmarshal number into Go struct field WebhookContext.items.spec.github.webhook.port of type string"}: json: cannot unmarshal number into Go struct field WebhookContext.items.spec.github.webhook.port of type string`
