### PR TITLE
feat(charts) : generic helm chart to test the different apps

### DIFF
--- a/charts/chorusapp/.helmignore
+++ b/charts/chorusapp/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/chorusapp/Chart.yaml
+++ b/charts/chorusapp/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: chorusapp
+description: A Helm chart for testing chorus app integration
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.0.1"

--- a/charts/chorusapp/apps/brainstorm.yaml
+++ b/charts/chorusapp/apps/brainstorm.yaml
@@ -1,0 +1,18 @@
+# Default values for brainstorm.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: registry.build.chorus-tre.local/brainstorm
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+imagePullSecrets:
+  - name: regcred
+
+env:
+  card: "none"
+  app_name: "brainstorm"
+  display: "workbench:80"
+  # if brainstorm is in another namespace than the workbench, use the following format
+  # display: "service.namespace-of-service.svc.cluster.local:80"

--- a/charts/chorusapp/apps/jupyterlab.yaml
+++ b/charts/chorusapp/apps/jupyterlab.yaml
@@ -1,0 +1,18 @@
+# Default values for jupyterlab.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: registry.build.chorus-tre.local/jupyterlab
+  pullPolicy: IfNotPresent
+  tag: "4.2.1-1"
+
+# imagePullSecrets:
+#   - name: regcred
+
+env:
+  card: "none"
+  app_name: "jupyterlab"
+  display: "workbench:80"
+  # if jupyterlab is in another namespace than the workbench, use the following format
+  # display: "service.namespace-of-service.svc.cluster.local:80"

--- a/charts/chorusapp/apps/localizer.yaml
+++ b/charts/chorusapp/apps/localizer.yaml
@@ -1,0 +1,18 @@
+# Default values for localizer.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: registry.build.chorus-tre.local/localizer
+  pullPolicy: IfNotPresent
+  tag: "4.4.5-1"
+  
+# imagePullSecrets:
+#   - name: regcred
+
+env:
+  card: "none"
+  app_name: "localizer"
+  display: "workbench:80"
+  # if localizer is in another namespace than the workbench, use the following format
+  # display: "service.namespace-of-service.svc.cluster.local:80"

--- a/charts/chorusapp/apps/trcanonymizer.yaml
+++ b/charts/chorusapp/apps/trcanonymizer.yaml
@@ -1,0 +1,18 @@
+# Default values for trcanonymizer.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: registry.build.chorus-tre.local/trcanonymizer
+  pullPolicy: IfNotPresent
+  tag: "1.1.0-1"
+
+# imagePullSecrets:
+#   - name: regcred
+
+env:
+  card: "none"
+  app_name: "trcanonymizer"
+  display: "workbench:80"
+  # if trcanonymizer is in another namespace than the workbench, use the following format
+  # display: "service.namespace-of-service.svc.cluster.local:80"

--- a/charts/chorusapp/templates/_helpers.tpl
+++ b/charts/chorusapp/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "chorusapp.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "chorusapp.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "chorusapp.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "chorusapp.labels" -}}
+helm.sh/chart: {{ include "chorusapp.chart" . }}
+{{ include "chorusapp.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "chorusapp.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "chorusapp.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/chorusapp/templates/deployment.yaml
+++ b/charts/chorusapp/templates/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "chorusapp.fullname" . }}
+  labels:
+    {{- include "chorusapp.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "chorusapp.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "chorusapp.labels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: CARD
+              value: "{{ .Values.env.card }}"
+            - name: APP_NAME
+              value: "{{ .Values.env.app_name }}"
+            - name: DISPLAY
+              value: "{{ .Values.env.display }}"

--- a/charts/chorusapp/values.yaml
+++ b/charts/chorusapp/values.yaml
@@ -1,0 +1,21 @@
+# This is a template file for being abble to launch an app
+# replace [app_name] with the name of the app you want to deploy
+
+# Default values for <app_name>.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: registry.build.chorus-tre.local/<app_name>
+  pullPolicy: IfNotPresent
+  tag: "1.0.0"
+  
+# imagePullSecrets:
+#   - name: regcred
+
+env:
+  card: "none"
+  app_name: "<app_name>"
+  display: "workbench:80"
+  # if <app_name> is in another namespace than the workbench, use the following format
+  # display: "service.namespace-of-service.svc.cluster.local:80"


### PR DESCRIPTION
In order to test the different apps when integrating them , we could have just one helm chart as per this pr and then pass a different value file to launch each app. This would prevent duplicating helm charts (even just localy) and provide one source of truth for apps configuration.

What say ye ? 