### PR TITLE
feat(charts): add trust-manager

### DIFF
--- a/charts/trust-manager/Chart.lock
+++ b/charts/trust-manager/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: trust-manager
+  repository: https://charts.jetstack.io
+  version: v0.12.0
+digest: sha256:e827a34813ae9429cdd102b40b25d97e63d8788a50c016f273cbc28c0cb9c8e6
+generated: "2024-08-20T10:49:37.609299+02:00"

--- a/charts/trust-manager/Chart.yaml
+++ b/charts/trust-manager/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+description: trust-manager is the easiest way to manage TLS trust bundles in Kubernetes clusters.
+name: trust-manager
+version: 0.0.1
+dependencies:
+  - name: trust-manager
+    version: 0.12.0
+    repository: https://charts.jetstack.io
+
+maintainers:
+  - name: greut
+    email: yoan.blan@chuv.ch

--- a/charts/trust-manager/values.yaml
+++ b/charts/trust-manager/values.yaml
@@ -1,0 +1,4 @@
+trust-manager:
+  crds:
+    enabled: true
+    keep: true


### PR DESCRIPTION
trust-manager can be an 'easy' way, to bootstrap our PKI, which will be useful for Vault (in the long run), but mostly for Postgres right now.