### PR TITLE
chore(charts): bump kube-prometheus-stack to 62.2.1

### DIFF
--- a/charts/kube-prometheus-stack/Chart.lock
+++ b/charts/kube-prometheus-stack/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
-  version: 61.8.0
-digest: sha256:7d285abdc754b4803e302c069250acbec5147d205598781e71347441f353256d
-generated: "2024-08-12T09:34:43.185735+02:00"
+  version: 62.2.1
+digest: sha256:f139d9237ac94bb9a916c6a85f04fcd15161722f2878cd524722efed52faacb7
+generated: "2024-08-23T09:03:16.183042+02:00"

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -4,8 +4,8 @@ maintainers:
   - name: greut
     email: yoan.blanc@chuv.ch
 name: kube-prometheus-stack
-version: 0.0.7
+version: 0.0.8
 dependencies:
   - name: kube-prometheus-stack
-    version: 61.8.0
+    version: 62.2.1
     repository: https://prometheus-community.github.io/helm-charts


### PR DESCRIPTION
Bump the prometheus-operator to v0.76.0

Signed-off-by: Yoan Blanc <yoan.blanc@chuv.ch>
