### PR TITLE
chore(charts): bump ArgoCD to 7.4.6

### DIFF
--- a/charts/argo-cd/Chart.lock
+++ b/charts/argo-cd/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: argo-cd
   repository: https://argoproj.github.io/argo-helm
-  version: 7.4.4
-digest: sha256:990e4ebef6493abb2a7590267191263e8c279679b963bb9aec33042e91daedcc
-generated: "2024-08-19T08:36:52.406408+02:00"
+  version: 7.4.6
+digest: sha256:48938b7f7e3b9f23887695ab3175344b5ac17b6002aa90fa6b8023752d1b40c1
+generated: "2024-08-27T11:42:02.226182+02:00"

--- a/charts/argo-cd/Chart.yaml
+++ b/charts/argo-cd/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 name: argo-cd
-version: 0.0.19
+version: 0.0.20
 description: A Helm chart for Argo CD, a declarative, GitOps continuous delivery tool for Kubernetes.
 dependencies:
   - name: argo-cd
-    version: 7.4.4
+    version: 7.4.6
     repository: https://argoproj.github.io/argo-helm
 
 maintainers:


### PR DESCRIPTION
Bumps argo-cd to v2.12.2

Signed-off-by: Yoan Blanc <yoan.blanc@chuv.ch>
