### PR TITLE
feat(charts): add Harbor

### DIFF
--- a/charts/harbor/Chart.lock
+++ b/charts/harbor/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: harbor
+  repository: https://helm.goharbor.io
+  version: 1.15.1
+digest: sha256:8d73f9bf3c876638c60beb4a07ba417e5df8c4e626459a69b8c56540b58d63f6
+generated: "2024-09-03T09:02:55.562088+02:00"

--- a/charts/harbor/Chart.yaml
+++ b/charts/harbor/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+description: An open source trusted cloud native registry that stores, signs, and scans content.
+name: harbor
+version: 0.0.1
+dependencies:
+  - name: harbor
+    version: 1.15.1
+    repository: https://helm.goharbor.io
+
+maintainers:
+  - name: greut
+    email: yoan.blan@chuv.ch

--- a/charts/harbor/README.md
+++ b/charts/harbor/README.md
@@ -1,0 +1,7 @@
+# Harbor
+
+Helm chart bundling [goharbor/harbor](https://github.com/goharbor/harbor-helm) embracing the HA setup, meaning Postgres and Redis/Valkey are externally managed.
+
+## Known issues
+
+- Authenticated Redis/Valkey is not supported with `helm template`: [harbor-helm#1641](https://github.com/goharbor/harbor-helm/issues/1641)

--- a/charts/harbor/templates/certificate.yaml
+++ b/charts/harbor/templates/certificate.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.certificate.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Release.Name }}-cert
+spec:
+  secretName: {{ .Values.certificate.secretName | default (printf "%s-secret" .Release.Name) | quote }}
+
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+
+  duration: {{ .Values.certificate.duration }}
+  renewBefore: {{ .Values.certificate.renewBefore }}
+
+  isCA: false
+  usages:
+    - server auth
+    - client auth
+
+  subject:
+    organizations:
+      - chorus
+
+  uris:
+    - spiffe://cluster.local/ns/{{ .Release.Namespace }}
+  privateKey:
+    rotationPolicy: Always
+
+  issuerRef:
+    name: {{ .Values.certificate.issuerRef.name }}
+    kind: {{ .Values.certificate.issuerRef.kind | default "Issuer" }}
+{{- end }}

--- a/charts/harbor/values.yaml
+++ b/charts/harbor/values.yaml
@@ -1,0 +1,105 @@
+harbor:
+  expose:
+    type: ingress
+    tls:
+      enabled: true
+      # Is done by the Ingress Controller
+      certSource: secret
+      secret:
+        secretName: harbor.build.chorus-tre.local-tls
+    ingress:
+      hosts:
+        core: harbor.build.chorus-tre.local
+      className: nginx
+      annotations:
+        cert-manager.io/cluster-issuer: letsencrypt-prod
+        nginx.ingress.kubernetes.io/ssl-redirect: "true"
+        nginx.ingress.kubernetes.io/proxy-body-size: "0"
+
+  externalURL: https://harbor.build.chorus-tre.local
+
+  persistence:
+    persistentVolumeClaim:
+      registry:
+        size: 500Gi
+      jobService:
+        size: 2Gi
+
+  updateStrategy:
+    type: Recreate # as RWM is not supported.
+
+  imageChartStorage:
+    type: filesystem # Using the above PVC
+
+  existingSecretAdminPassword: harbor-secret
+  existingSecretAdminPasswordKey: HARBOR_ADMIN_PASSWORD
+
+  # Key is:
+  #  - secretKey # 16 charts
+  existingSecretSecretKey: harbor-secret
+
+  metrics:
+    enabled: true
+    serviceMonitor:
+      enabled: true
+
+  core:
+    # Key is:
+    # - secret # 16 chars
+    existingSecret: harbor-secret
+    existingXsrfSecret: harbor-secret
+    existingXsrfSecretKey: CSRF_KEY # 32 chars
+
+    secretName: harbor-tls-secret
+
+  jobservice:
+    existingSecret: harbor-secret
+    existingSecretKey: JOBSERVICE_SECRET
+    jobLoggers:
+      - database
+
+  registry:
+    existingSecret: harbor-secret
+    existingSecretKey: REGISTRY_HTTP_SECRET # string of 16 chars
+    credentials:
+      username: "admin"
+      password: ""
+      # Keys are:
+      #  - REGISTRY_PASSWD
+      #  - REGISTRY_HTPASSWD
+      existingSecret: harbor-secret
+
+  database:
+    type: external
+    external:
+      host: "chorus-local-harbor-db-postgresql"
+      port: "5432"
+      username: "harbor"
+      password: ""
+      # Key is:
+      # - password
+      existingSecret: harbor-db-secret
+      sslmode: require
+
+  redis:
+    type: external
+    external:
+      addr: "chorus-local-harbor-cache-valkey-master:6379"
+      # Auth will not work with helm template,
+      # See: https://github.com/goharbor/harbor-helm/issues/1641
+      password: ""
+
+certificate:
+
+
+certificate:
+  enabled: false
+
+  # Same as above: harbor.core.secretName
+  secretName: harbor-tls-secret
+
+  duration: 2169h # 90d
+  renewBefore: 360h # 15d
+
+  issuerRef:
+    name: CHANGEME-issuer


### PR DESCRIPTION
Another try at DSDIP-389.

- [x] needs Valkey #160 

To spoil the picture below, you see myself connected via Keycloak OIDC and the existing charts that were sync'd from the current [registry](https://registry-ui.build.chorus-tre.ch/).

<img width="1303" alt="Capture d’écran 2024-09-11 à 14 24 57" src="https://github.com/user-attachments/assets/2b253119-cbf9-4a1a-a519-d3cfb32da1a0">
