### PR TITLE
feat(deployment): use progressiveSync in dev

### DIFF
--- a/deployment/applicationset/applicationset-chorus-dev.yaml
+++ b/deployment/applicationset/applicationset-chorus-dev.yaml
@@ -13,9 +13,32 @@ spec:
       revision: HEAD
       files:
       - path: "chorus-dev/*/config.json"
+  strategy:
+    type: RollingSync
+    rollingSync:
+      steps:
+        - matchExpressions:
+            - key: stepName
+              operator: In
+              values:
+                - infrastructure
+        - matchExpressions:
+            - key: stepName
+              operator: In
+              values:
+                - database
+          maxUpdate: 20% # don't break them all at once.
+        - matchExpressions:
+            - key: stepName
+              operator: In
+              values:
+                - application
+          maxUpdate: 20% # don't break them all at once
   template:
     metadata:
       name: '{{index .path.segments 0}}-{{.path.basename}}'
+      labels:
+        stepName: '{{ if hasKey . "stepName" }}{{ .stepName }}{{ else }}application{{ end }}'
       #annotations:
       #  argocd-image-updater.argoproj.io/image-list: '{{.images}}'
     spec:
@@ -41,4 +64,4 @@ spec:
         syncOptions:
           - CreateNamespace=true
           - preserveResourcesOnDeletion=true
-          - 'ServerSideApply={{if hasKey . "serverSideApply" }}{{ .serverSideApply }}{{ else }}false{{ end }}'
+          - 'ServerSideApply={{ if hasKey . "serverSideApply" }}{{ .serverSideApply }}{{ else }}false{{ end }}'


### PR DESCRIPTION
The goal is to tag the various (Argo) application with their stepName and have nice rollouts. Mostly useful when bootstrapping the whole thing or after an outage.

Sauce? There:

- https://akuity.io/blog/application-dependencies-with-argo-cd/
- https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Progressive-Syncs/