### PR TITLE
fix(argo-ci) : no need for - for buildx

### DIFF
--- a/charts/argo-ci/Chart.yaml
+++ b/charts/argo-ci/Chart.yaml
@@ -18,4 +18,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.81
+version: 0.0.82

--- a/charts/argo-ci/templates/docker-build-template.yaml
+++ b/charts/argo-ci/templates/docker-build-template.yaml
@@ -96,9 +96,9 @@ spec:
             --cache-to=type=registry,ref=${tag_cache}:${version},mode=max,image-manifest=true \
             --cache-to=type=registry,ref=${tag_cache}:latest,mode=max,image-manifest=true";
 
-          docker-buildx create --name "${BUILDER_NAME}" --driver docker-container;
+          docker buildx create --name "${BUILDER_NAME}" --driver docker-container;
 
-          docker-buildx build
+          docker buildx build
           --pull
           --builder ${BUILDER_NAME}
           --file "${DOCKERFILE}"


### PR DESCRIPTION
There is a symlink to do when setting up **docker-buildx** on Mac in order for it to be able to run without the dash

```
mkdir -p ~/.docker/cli-plugins
ln -sfn /opt/homebrew/opt/docker-buildx/bin/docker-buildx ~/.docker/cli-plugins/docker-buildx
```

and then you can run **docker buildx**

