### PR TITLE
fix(argo-ci): specify the entrypoint for sidecars

### DIFF
--- a/charts/argo-ci/Chart.yaml
+++ b/charts/argo-ci/Chart.yaml
@@ -18,4 +18,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.88
+version: 0.0.89

--- a/charts/argo-ci/templates/build-images-sensor.yaml
+++ b/charts/argo-ci/templates/build-images-sensor.yaml
@@ -149,6 +149,7 @@ spec:
                     sidecars:
                       - name: dind
                         image: harbor.build.chorus-tre.ch/docker_proxy/library/docker:28.1.1-dind
+                        command: ["dockerd-entrypoint.sh"]
                         env:
                           - name: DOCKER_TLS_CERTDIR
                             value: ""

--- a/charts/argo-ci/templates/docker-build-template.yaml
+++ b/charts/argo-ci/templates/docker-build-template.yaml
@@ -112,6 +112,7 @@ spec:
     sidecars:
       - name: dind
         image: "harbor.build.chorus-tre.ch/docker_proxy/library/docker:28.1.1-dind"
+        command: ["dockerd-entrypoint.sh"]
         env:
           - name: DOCKER_TLS_CERTDIR
             value: ""


### PR DESCRIPTION
This is needed because:

We're using the Emissary executor, which requires the image’s CMD/ENTRYPOINT to be retrievable from the image index/manifest. Our registry doesn’t expose this then, argo-worflows fails.
