### PR TITLE
exclude argo-deploy from generator

### DIFF
--- a/charts/argo-deploy/templates/chorus-applicationset.yaml
+++ b/charts/argo-deploy/templates/chorus-applicationset.yaml
@@ -15,6 +15,8 @@ spec:
         revision: {{ .envRepoRevision | default "HEAD" | quote }}
         files:
           - path: {{ printf "\"%s/*/config.json\"" .name }}
+          - path: {{ printf "\"%s/argo-deploy/config.json\"" .name }}
+            exclude: true
   strategy:
     type: RollingSync
     rollingSync:


### PR DESCRIPTION
Exclude argo-deploy from ApplicationSet to allow setting self-heal to false for development

I followed the documentation: https://argo-cd.readthedocs.io/en/latest/operator-manual/applicationset/Generators-Git/#exclude-files
