### PR TITLE
fix(charts): added namespace to argo-deploy

### DIFF
--- a/charts/argo-deploy/Chart.yaml
+++ b/charts/argo-deploy/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.10
+version: 0.0.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/argo-deploy/templates/chorus-applicationset.yaml
+++ b/charts/argo-deploy/templates/chorus-applicationset.yaml
@@ -4,6 +4,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: ApplicationSet
 metadata:
   name: {{ .name | quote }}
+  namespace: argocd
 spec:
   syncPolicy:
     preserveResourcesOnDeletion: true

--- a/charts/argo-deploy/templates/chorus-project.yaml
+++ b/charts/argo-deploy/templates/chorus-project.yaml
@@ -4,6 +4,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: AppProject
 metadata:
   name: {{ .name | quote }}
+  namespace: argocd 
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:


### PR DESCRIPTION
The namespace isn't necessary for other charts, but since this one must first be installed with kubectl, we added it to limit deployment mistakes.