### PR TITLE
add the possibility to feed in a configmap to initialize the db

### DIFF
--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -4,7 +4,7 @@ name: mariadb
 maintainers:
   - name: iDmple
     email: nathalie.casati@chuv.ch
-version: 0.0.13
+version: 0.0.14
 dependencies:
   - name: mariadb
     version: 20.3.1

--- a/charts/mariadb/values.yaml
+++ b/charts/mariadb/values.yaml
@@ -26,3 +26,4 @@ mariadb:
       certManager:
         existingIssuer: CHANGEME-issuer
         existingIssuerKind: ClusterIssuer
+  initdbScriptsConfigMap: "mariadb-initdb"


### PR DESCRIPTION
We are mixing two ways of setting up credentials at the moment

Set username and database, MariaDB generates credentials: https://github.com/CHORUS-TRE/environments/blob/eecfe88d65f8de073fafebaffe423c2c862291d5/chorus-exodev/matomo-db/values.yaml#L3

Set existingSecret: https://github.com/CHORUS-TRE/chorus-tre/blob/d4758a429f1ccad56039b424aa9327a58e5faefb/charts/mariadb/values.yaml#L3

existingSecret takes precedence over username and database, so the configuration in the environment repo are never picked up. existingSecret assumes that we create the username and password manually.

So going forward I would
	1.	stick to the existingSecret approach to keep full control on the password generated
	2.	create the credentials secret with terraform
	3.	enable initdbscriptsconfigmap in our wrapper helm chart
	4.	create the configmap setting up the db and username as specified in the matomo values with terraform

https://artifacthub.io/packages/helm/bitnami/mariadb#update-credentials