### PR TITLE
fix: rm loose netpols from bitnami and create our own

### DIFF
--- a/charts/mariadb/Chart.yaml
+++ b/charts/mariadb/Chart.yaml
@@ -4,7 +4,7 @@ name: mariadb
 maintainers:
   - name: iDmple
     email: nathalie.casati@chuv.ch
-version: 0.0.16
+version: 0.0.17
 dependencies:
   - name: mariadb
     version: 20.3.1

--- a/charts/mariadb/templates/ciliumnetworkpolicy.yaml
+++ b/charts/mariadb/templates/ciliumnetworkpolicy.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.chorusNetworkPolicy.enabled .Values.chorusNetworkPolicy.enabled_l7_waf }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-mariadb-chorus
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/name: mariadb
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: mariadb
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  ingress:
+  # Default: Allow ingress from same namespace only on MySQL port
+  - fromEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: {{ .Release.Namespace | quote }}
+    toPorts:
+    - ports:
+      - port: "3306"
+        protocol: TCP
+  {{- with .Values.chorusNetworkPolicy.ingress }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- if .Values.chorusNetworkPolicy.egress }}
+  egress:
+    {{- toYaml .Values.chorusNetworkPolicy.egress | nindent 2 }}
+  {{- else }}
+  egress: [] # Deny all egress for database (empty array = no rules)
+  {{- end }}
+{{- end }} 

--- a/charts/mariadb/templates/networkpolicy.yaml
+++ b/charts/mariadb/templates/networkpolicy.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.chorusNetworkPolicy.enabled (not .Values.chorusNetworkPolicy.enabled_l7_waf) }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-mariadb-chorus
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/name: mariadb
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: mariadb
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Default: Allow ingress from same namespace only on MySQL port
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
+    ports:
+    - protocol: TCP
+      port: 3306
+  {{- with .Values.chorusNetworkPolicy.ingress }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- if .Values.chorusNetworkPolicy.egress }}
+  egress:
+    {{- toYaml .Values.chorusNetworkPolicy.egress | nindent 2 }}
+  {{- else }}
+  egress: [] # Deny all egress for database (empty array = no rules)
+  {{- end }}
+{{- end }} 

--- a/charts/mariadb/values.yaml
+++ b/charts/mariadb/values.yaml
@@ -1,3 +1,12 @@
+# Custom Chorus NetworkPolicy configuration
+chorusNetworkPolicy:
+  enabled: true
+  enabled_l7_waf: false
+  # Default ingress: Allow from same namespace only
+  ingress: []
+  # Default egress: Deny all (databases don't initiate outbound connections)
+  egress: []
+
 mariadb:
   image:
     repository: bitnamilegacy/mariadb
@@ -6,6 +15,9 @@ mariadb:
       allowInsecureImages: true
   auth:
     existingSecret: "mariadb-secret"
+  # Disable Bitnami's NetworkPolicy (we use custom Chorus NetworkPolicy templates)
+  networkPolicy:
+    enabled: false
   primary:
     livenessProbe:
       timeoutSeconds: 10

--- a/charts/postgresql/Chart.yaml
+++ b/charts/postgresql/Chart.yaml
@@ -5,7 +5,7 @@ maintainers:
   - name: iDmple
     email: nathalie.casati@chuv.ch
 
-version: 0.0.19
+version: 0.0.20
 dependencies:
   - name: postgresql
     version: 16.7.21

--- a/charts/postgresql/templates/ciliumnetworkpolicy.yaml
+++ b/charts/postgresql/templates/ciliumnetworkpolicy.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.chorusNetworkPolicy.enabled .Values.chorusNetworkPolicy.enabled_l7_waf }}
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-postgresql-chorus
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  ingress:
+  # Default: Allow ingress from same namespace only on PostgreSQL port
+  - fromEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: {{ .Release.Namespace | quote }}
+    toPorts:
+    - ports:
+      - port: "5432"
+        protocol: TCP
+  {{- with .Values.chorusNetworkPolicy.ingress }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- if .Values.chorusNetworkPolicy.egress }}
+  egress:
+    {{- toYaml .Values.chorusNetworkPolicy.egress | nindent 2 }}
+  {{- else }}
+  egress: [] # Deny all egress for database (empty array = no rules)
+  {{- end }}
+{{- end }} 

--- a/charts/postgresql/templates/networkpolicy.yaml
+++ b/charts/postgresql/templates/networkpolicy.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.chorusNetworkPolicy.enabled (not .Values.chorusNetworkPolicy.enabled_l7_waf) }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-postgresql-chorus
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  # Default: Allow ingress from same namespace only on PostgreSQL port
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
+    ports:
+    - protocol: TCP
+      port: 5432
+  {{- with .Values.chorusNetworkPolicy.ingress }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+  {{- if .Values.chorusNetworkPolicy.egress }}
+  egress:
+    {{- toYaml .Values.chorusNetworkPolicy.egress | nindent 2 }}
+  {{- else }}
+  egress: [] # Deny all egress for database (empty array = no rules)
+  {{- end }}
+{{- end }} 

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -1,3 +1,12 @@
+# Custom Chorus NetworkPolicy configuration
+chorusNetworkPolicy:
+  enabled: true
+  enabled_l7_waf: false
+  # Default ingress: Allow from same namespace only
+  ingress: []
+  # Default egress: Deny all (databases don't initiate outbound connections)
+  egress: []
+
 postgresql:
   image:
     repository: bitnamilegacy/postgresql
@@ -50,13 +59,18 @@ postgresql:
     serviceMonitor:
       enabled: true
 
+  # Disable Bitnami's NetworkPolicy (we use custom Chorus NetworkPolicy templates)
   primary:
+    networkPolicy:
+      enabled: false
     # See: https://github.com/bitnami/charts/blob/main/bitnami/common/templates/_resources.tpl#L15
     resourcesPreset: "small"
     persistence:
       size: 1Gi
 
   readReplicas:
+    networkPolicy:
+      enabled: false
     resourcesPreset: "nano"
 
 certificate:


### PR DESCRIPTION
## 🔒 Network Policy Implementation - Database Charts - Validation Report

### Changes Made

#### 1. **MariaDB Chart (`chorus-tre/charts/mariadb/`)**
- ✅ Added custom `networkpolicy.yaml` template with namespace-only ingress + deny-all egress
- ✅ Added custom `ciliumnetworkpolicy.yaml` template for L7 WAF support
- ✅ Disabled Bitnami's permissive NetworkPolicy (`mariadb.networkPolicy.enabled: false`)
- ✅ Added `chorusNetworkPolicy` values section for configuration
- ✅ Chart version: `0.0.16 → 0.0.17`

#### 2. **PostgreSQL Chart (`chorus-tre/charts/postgresql/`)**
- ✅ Added custom `networkpolicy.yaml` template with namespace-only ingress + deny-all egress
- ✅ Added custom `ciliumnetworkpolicy.yaml` template for L7 WAF support
- ✅ Disabled Bitnami's permissive NetworkPolicy (`primary.networkPolicy.enabled: false`, `readReplicas.networkPolicy.enabled: false`)
- ✅ Added `chorusNetworkPolicy` values section for configuration
- ✅ Chart version: `0.0.19 → 0.0.20`

### Network Policy Configuration

**Restrictive Default-Deny Policy for Databases:**

**Ingress:**
- ✅ Allow from **same namespace only** on database port (3306/5432)

**Egress:**
- ✅ **Deny all** (`egress: []`) - databases are servers and don't initiate outbound connections

### Key Technical Fixes

#### **Fix 1: Bitnami NetworkPolicy Conflicts**
- **Problem**: Old permissive Bitnami NetworkPolicies (`From: <any>`) were still active and conflicting
- **Root Cause**: NetworkPolicies are **additive** - if ANY policy allows traffic, it passes
- **Solution**: 
  - Disabled Bitnami policies in `values.yaml`
  - Manually deleted old policies from cluster during testing
  - Verified templates no longer render Bitnami policies

#### **Fix 2: PostgreSQL NetworkPolicy Structure**
- **Problem**: PostgreSQL Bitnami chart uses nested structure (`primary.networkPolicy.enabled` not `networkPolicy.enabled`)
- **Solution**: Updated `values.yaml` to disable at correct nesting level

### Validation Results (exodev cluster)

| Test Case | Source → Destination | Expected | Actual | Status |
|-----------|---------------------|----------|--------|--------|
| **Positive** | didata app → didata MariaDB | ✅ ALLOW | ✅ Connected | **PASS** |
| **Negative** | i2b2 pod → didata MariaDB | ❌ DENY | ❌ Timeout (exit 124) | **PASS** |
| **Negative** | didata app → i2b2 PostgreSQL | ❌ DENY | ❌ Operation not permitted | **PASS** |

### NetworkPolicy Details

**MariaDB** (`chorus-exodev-didata-db-mariadb-chorus`):
```yaml
Name:         chorus-exodev-didata-db-mariadb-chorus
Namespace:    didata
Spec:
  PodSelector: app.kubernetes.io/name=mariadb
  
  Ingress:
    - Port: 3306/TCP
      From: Namespace didata only
  
  Egress:
    <none> (deny all)
```

**PostgreSQL** (`chorus-exodev-i2b2-db-postgresql-chorus`):
```yaml
Name:         chorus-exodev-i2b2-db-postgresql-chorus
Namespace:    i2b2
Spec:
  PodSelector: app.kubernetes.io/name=postgresql
  
  Ingress:
    - Port: 5432/TCP
      From: Namespace i2b2 only
  
  Egress:
    <none> (deny all)
```

### Template Validation

✅ **MariaDB**: Renders only custom NetworkPolicy (no Bitnami policy)
```bash
$ helm template test-mariadb ./charts/mariadb | grep -c "kind: NetworkPolicy"
1
```

✅ **PostgreSQL**: Renders only custom NetworkPolicy (no Bitnami policy)
```bash
$ helm template test-postgresql ./charts/postgresql | grep -c "kind: NetworkPolicy"
1
```

### Security Impact

- 🔒 **Closed permissive access**: Old Bitnami policies allowed `From: <any>` and `To: <any>`
- 🔒 **Namespace isolation**: Databases now **only** accept connections from same namespace
- 🔒 **Zero egress**: Databases cannot initiate outbound connections (appropriate for database role)
- 🔒 **Cross-namespace verified**: Confirmed i2b2 ↔ didata database traffic is **BLOCKED**

### Notes

- ⚠️ **Critical**: Old permissive Bitnami NetworkPolicies must be **manually deleted** from existing deployments as they conflict with our restrictive policies
- ✅ Future deployments will only create our custom restrictive policies
- ✅ Both standard NetworkPolicy and CiliumNetworkPolicy templates provided for flexibility
- ✅ Mutual exclusivity enforced via `chorusNetworkPolicy.enabled_l7_waf` flag

### Deployment Checklist

When deploying to environments:
1. ✅ Apply new chart version
2. ⚠️ **Manually delete old Bitnami NetworkPolicies**:
   ```bash
   kubectl delete networkpolicy <release-name>-mariadb -n <namespace>
   kubectl delete networkpolicy <release-name>-postgresql -n <namespace>
   ```
3. ✅ Verify only custom `-chorus` NetworkPolicies remain
4. ✅ Test legitimate traffic still works (app → own database)

**Ready for review and merge** 🚀