### PR TITLE
fix(chorus-gateway): use fromEntities cluster instead of podCIDR in CNP (0.0.8)

### DIFF
--- a/charts/chorus-gateway/Chart.yaml
+++ b/charts/chorus-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: chorus-gateway
 description: Envoy Gateway HTTPRoutes and SecurityPolicies for internal CHORUS services
-version: 0.0.7
+version: 0.0.8
 maintainers:
   - name: iDmple
     email: nathalie.casati@chuv.ch

--- a/charts/chorus-gateway/templates/ciliumnetworkpolicies.yaml
+++ b/charts/chorus-gateway/templates/ciliumnetworkpolicies.yaml
@@ -1,8 +1,10 @@
-{{- if .Values.podCIDR }}
 {{- range .Values.shellServices }}
 ---
-# Restrict ingress on the Envoy-remapped port (gatewayPort + 10000) to pod CIDR only.
-# This blocks external users whose real IPs are not in podCIDR (enforced by externalTrafficPolicy: Local).
+# Restrict ingress on the Envoy-remapped port (gatewayPort + 10000) to cluster-internal traffic only.
+# fromEntities: cluster matches all pods and nodes within the cluster regardless of IP masquerading,
+# blocking external users while allowing workspace pods. loadBalancerSourceRanges is not used because
+# Cilium masquerades pod IPs to node IPs when connecting to MetalLB VIPs, making CIDR-based filtering
+# unreliable for pod traffic.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -15,8 +17,8 @@ spec:
     matchLabels:
       app.kubernetes.io/managed-by: envoy-gateway
   ingress:
-    - fromCIDR:
-        - {{ $.Values.podCIDR | quote }}
+    - fromEntities:
+        - cluster
       toPorts:
         - ports:
             - port: {{ add .gatewayPort 10000 | toString | quote }}
@@ -47,5 +49,4 @@ spec:
         - ports:
             - port: {{ .containerPort | toString | quote }}
               protocol: TCP
-{{- end }}
 {{- end }}

--- a/charts/chorus-gateway/values.yaml
+++ b/charts/chorus-gateway/values.yaml
@@ -1,4 +1,5 @@
 # Cluster pod CIDR — used in SecurityPolicy to restrict access to workspace pods only.
+# Not used for CiliumNetworkPolicies (those use fromEntities: cluster instead of CIDR).
 # Must match the value set in gateway-helm.
 # Must be set in environment values.
 # To find it: kubectl get nodes -o jsonpath='{.items[*].spec.podCIDR}'


### PR DESCRIPTION
## Replace podCIDR with fromEntities cluster in CiliumNetworkPolicy (0.0.8)

The `gitlab-shell-gateway-ingress` CNP restricted ingress to Envoy pods using `fromCIDR: podCIDR`. This broke HTTPS (port 10443) for all workspaces: adding any ingress rule to Cilium-managed Envoy pods enables deny-by-default for ALL other ingress on those pods, including port 10443 (confirmed broken on chorus-int 2026-04-07).

**Why `fromCIDR` breaks things but `fromEntities: cluster` does not**

Cilium's docs are explicit: CIDR rules do not apply to traffic where both sides use reserved Cilium identities (host, remote-node, health, init, etc.). When `fromCIDR` triggers deny-by-default on Envoy pods, node-level traffic — kubelet health checks, kube-proxy, Cilium health probes — arrives with reserved identities, not pod CIDR addresses, and gets dropped. This breaks Envoy's ability to receive connections entirely.

`fromEntities: cluster` expands at runtime to explicitly include `host`, `remote-node`, `init`, `health`, `ingress`, `unmanaged`, and `kube-apiserver` — covering all reserved identities. No gaps remain. This behavior is intentional and stable across Cilium v1.14–v1.18+ (see `pkg/policy/api/entity.go` `InitEntities()`).

**Security layers in place**

- `gitlab-shell-gateway-ingress` CNP (`fromEntities: cluster`): restricts port 10022 (SSH) and 10443 (HTTPS) on Envoy pods to cluster-internal traffic only. With `externalTrafficPolicy: Local`, external clients are classified as `world` by Cilium and denied.
- Operator workspace CNP (`toEndpoints: envoy-gateway-system` + `serverNames`): workspace pods can only egress to listed FQDNs on Envoy — frontend/backend on nginx remain blocked.
- Envoy `SecurityPolicy` (`clientCIDRs: podCIDR`): blocks external browsers from gitlab/i2b2 HTTPRoutes at the application layer.
- `gitlab-shell-service-ingress` CNP: defense-in-depth — gitlab-shell pod only accepts connections from Envoy pods directly.

**Security trade-off:** `fromEntities: cluster` is broader than `podCIDR` in intent — it allows all cluster-internal traffic (nodes, system pods, any namespace), not just workspace pods. This is acceptable given the CIDR approach was fundamentally broken, and the other layers provide compensating controls.

The `podCIDR` gate (`{{- if .Values.podCIDR }}`) is removed — CNPs are now always emitted when `shellServices` is configured.