### PR TITLE
fix(chorus-gateway): rename CNP and add port 10443 (0.0.9)

### DIFF
--- a/charts/chorus-gateway/Chart.yaml
+++ b/charts/chorus-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: chorus-gateway
 description: Envoy Gateway HTTPRoutes and SecurityPolicies for internal CHORUS services
-version: 0.0.8
+version: 0.0.9
 maintainers:
   - name: iDmple
     email: nathalie.casati@chuv.ch

--- a/charts/chorus-gateway/templates/ciliumnetworkpolicies.yaml
+++ b/charts/chorus-gateway/templates/ciliumnetworkpolicies.yaml
@@ -22,6 +22,7 @@ spec:
       toPorts:
         - ports:
             {{- if .Values.routes }}
+            # All HTTPRoutes use gateway port 443 → Envoy remaps to 10443.
             - port: "10443"
               protocol: TCP
             {{- end }}

--- a/charts/chorus-gateway/templates/ciliumnetworkpolicies.yaml
+++ b/charts/chorus-gateway/templates/ciliumnetworkpolicies.yaml
@@ -1,17 +1,17 @@
-{{- range .Values.shellServices }}
+{{- if or .Values.routes .Values.shellServices }}
 ---
-# Restrict ingress on the Envoy-remapped port (gatewayPort + 10000) to cluster-internal traffic only.
-# fromEntities: cluster matches all pods and nodes within the cluster regardless of IP masquerading,
-# blocking external users while allowing workspace pods. loadBalancerSourceRanges is not used because
-# Cilium masquerades pod IPs to node IPs when connecting to MetalLB VIPs, making CIDR-based filtering
-# unreliable for pod traffic.
+# Restrict ingress on all Envoy pods to cluster-internal traffic only.
+# fromEntities: cluster matches all pods and nodes within the cluster regardless of IP
+# masquerading, blocking external users while allowing workspace pods.
+# Adding any ingress rule triggers Cilium deny-by-default for ALL other ingress on the
+# matched pods, so every Envoy listener port must be explicitly listed here.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: {{ .name }}-gateway-ingress
-  namespace: {{ $.Values.gateway.namespace }}
+  name: envoy-gateway-ingress
+  namespace: {{ .Values.gateway.namespace }}
   labels:
-    {{- include "chorus-gateway.labels" $ | nindent 4 }}
+    {{- include "chorus-gateway.labels" . | nindent 4 }}
 spec:
   endpointSelector:
     matchLabels:
@@ -21,8 +21,17 @@ spec:
         - cluster
       toPorts:
         - ports:
+            {{- if .Values.routes }}
+            - port: "10443"
+              protocol: TCP
+            {{- end }}
+            {{- range .Values.shellServices }}
             - port: {{ add .gatewayPort 10000 | toString | quote }}
               protocol: TCP
+            {{- end }}
+{{- end }}
+
+{{- range .Values.shellServices }}
 ---
 # Defense-in-depth: restrict ingress on the container port to Envoy pods only.
 # Envoy terminates the client TCP connection and opens a new one to the service pod,

--- a/charts/chorus-gateway/values.yaml
+++ b/charts/chorus-gateway/values.yaml
@@ -43,8 +43,10 @@ routes: []
 #     gatewayPort: 22
 tcpRoutes: []
 
-# Shell services — each entry creates two CiliumNetworkPolicies restricting SSH access
-# to workspace pods only. Requires podCIDR to be set.
+# Shell services — each entry creates a CiliumNetworkPolicy restricting ingress on the
+# service container port to Envoy pods only (defense-in-depth).
+# A single envoy-gateway-ingress CNP (generated if routes or shellServices exist) restricts
+# all Envoy pod ingress to cluster-internal traffic, blocking external users.
 # gatewayPort must match a tcp.listeners entry in gateway-helm (Envoy remaps it to gatewayPort+10000).
 #
 # shellServices:


### PR DESCRIPTION
## Fix envoy-gateway-ingress CNP

The `gitlab-shell-gateway-ingress` CiliumNetworkPolicy selected ALL Envoy pods (`app.kubernetes.io/managed-by: envoy-gateway`) but only allowed port 10022. Since adding any ingress rule to a Cilium endpoint triggers deny-by-default for all other ingress, port 10443 (HTTPS) was blocked — breaking workspace access to GitLab and i2b2 on port 443.

- Rename `gitlab-shell-gateway-ingress` → `envoy-gateway-ingress` to reflect that it applies to all Envoy pods, not just gitlab-shell
- Move the CNP out of the `shellServices` range loop — generate once if `routes` or `shellServices` exist
- Add port 10443 (HTTPS) alongside port 10022 (SSH) in the toPorts rule
- Fix `shellServices` comment in values.yaml (remove stale "Requires podCIDR" reference)

**Note:** The old `gitlab-shell-gateway-ingress` CNP must be manually deleted from the cluster after deploy, since the new CNP has a different name.