### PR TITLE
feat(keycloak, gitlab): add GitLab OIDC client and enable OmniAuth (keycloak 0.0.42, gitlab 0.0.9)

### DIFF
--- a/charts/gitlab/Chart.yaml
+++ b/charts/gitlab/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Web-based Git-repository manager with wiki and issue-tracking features.
 name: gitlab
-version: 0.0.8
+version: 0.0.9
 dependencies:
   - name: gitlab
     version: 9.9.3

--- a/charts/gitlab/values.yaml
+++ b/charts/gitlab/values.yaml
@@ -59,7 +59,12 @@ gitlab:
       packages:
         enabled: false
       omniauth:
-        enabled: false
+        enabled: true
+        allowSingleSignOn: ['openid_connect']
+        blockAutoCreatedUsers: true
+        providers:
+          - secret: gitlab-keycloak-oidc
+            key: provider
       smtp:
         enabled: false
 

--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Keycloak is a high performance Java-based identity and access management solution. It lets developers add an authentication layer to their applications with minimum effort.
 name: keycloak
-version: 0.0.41
+version: 0.0.42
 dependencies:
   - name: keycloak
     version: 24.5.2

--- a/charts/keycloak/files/realm/remote/chorus-realm.yaml
+++ b/charts/keycloak/files/realm/remote/chorus-realm.yaml
@@ -89,6 +89,30 @@ clients:
     optionalClientScopes:
       - "offline_access"
     access: {}
+  - clientId: "gitlab"
+    name: "GitLab"
+    rootUrl: "$(GITLAB_ROOT_URL)"
+    adminUrl: "$(GITLAB_ADMIN_URL)"
+    baseUrl: "$(GITLAB_BASE_URL)"
+    secret: "$(GITLAB_CLIENT_SECRET)"
+    redirectUris: $(GITLAB_REDIRECT_URIS)
+    webOrigins: $(GITLAB_WEB_ORIGINS)
+    directAccessGrantsEnabled: false
+    publicClient: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "false"
+      post.logout.redirect.uris: "+"
+    defaultClientScopes:
+      - web-origins
+      - acr
+      - profile
+      - roles
+      - basic
+      - email
+    optionalClientScopes:
+      - "offline_access"
+    access: {}
 clientScopes:
   - name: "acr"
     description: "OpenID Connect scope for add acr (authentication context class reference)\

--- a/charts/keycloak/templates/client-config.yaml
+++ b/charts/keycloak/templates/client-config.yaml
@@ -12,6 +12,12 @@ data:
   CHORUS_BASE_URL: {{ .Values.client.chorus.baseUrl | quote }}
   CHORUS_REDIRECT_URIS: {{ .Values.client.chorus.redirectUris | quote }}
   CHORUS_WEB_ORIGINS: {{ .Values.client.chorus.webOrigins | quote }}
+  # gitlab
+  GITLAB_ROOT_URL: {{ .Values.client.gitlab.rootUrl | quote }}
+  GITLAB_ADMIN_URL: {{ .Values.client.gitlab.adminUrl | quote }}
+  GITLAB_BASE_URL: {{ .Values.client.gitlab.baseUrl | quote }}
+  GITLAB_REDIRECT_URIS: {{ .Values.client.gitlab.redirectUris | quote }}
+  GITLAB_WEB_ORIGINS: {{ .Values.client.gitlab.webOrigins | quote }}
   # matomo
   MATOMO_ROOT_URL: {{ .Values.client.matomo.rootUrl | quote }}
   MATOMO_ADMIN_URL: {{ .Values.client.matomo.adminUrl | quote }}

--- a/charts/keycloak/values.yaml
+++ b/charts/keycloak/values.yaml
@@ -322,6 +322,12 @@ client:
     baseUrl: "/"
     redirectUris: '["http://backend.local/*","http://chorus.local/*"]'
     webOrigins: '["http://backend.local/*","http://chorus.local/*"]'
+  gitlab:
+    rootUrl: "http://gitlab.local"
+    adminUrl: "http://gitlab.local"
+    baseUrl: "/"
+    redirectUris: '["http://gitlab.local/users/auth/openid_connect/callback"]'
+    webOrigins: '["http://gitlab.local"]'
   matomo:
     rootUrl: "http://makoto.local"
     adminUrl: "http://makoto.local"


### PR DESCRIPTION
## Add GitLab Keycloak SSO

### Keycloak (0.0.42)
- Add `gitlab` OIDC client to the `chorus` realm in `chorus-realm.yaml`
- Add `GITLAB_*` environment variables in `client-config.yaml` ConfigMap
- Add default client URLs in keycloak `values.yaml`

### GitLab (0.0.9)
- Enable OmniAuth with `openid_connect` provider
- `blockAutoCreatedUsers: true` — admin must approve new users
- Provider config referenced from `gitlab-keycloak-oidc` secret (created manually per-cluster)

### Pre-deploy
Create secrets on the target cluster before deploying:
- Add `GITLAB_CLIENT_SECRET` to `keycloak-client-secret` in keycloak namespace
- Create `gitlab-keycloak-oidc` secret in gitlab namespace with the OIDC provider JSON