### PR TITLE
fix(i2b2-wildfly): allow envoy-gateway ingress in network policy (0.0.8)

### DIFF
--- a/charts/i2b2-wildfly/Chart.yaml
+++ b/charts/i2b2-wildfly/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.7
+version: 0.0.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/i2b2-wildfly/values.yaml
+++ b/charts/i2b2-wildfly/values.yaml
@@ -51,7 +51,7 @@ networkPolicy:
   enabled_l7_waf: false
   # Note: When enabled_l7_waf is true, a CiliumNetworkPolicy is created instead of standard K8s NetworkPolicy
   ingress:
-  # Allow ingress-nginx and i2b2-frontend to access wildfly
+  # Allow ingress-nginx, envoy-gateway, and i2b2-frontend to access wildfly
   - from:
     - namespaceSelector:
         matchLabels:
@@ -60,6 +60,16 @@ networkPolicy:
         matchLabels:
           app.kubernetes.io/name: ingress-nginx
           app.kubernetes.io/component: controller
+    ports:
+    - protocol: TCP
+      port: 8080
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: envoy-gateway-system
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/managed-by: envoy-gateway
     ports:
     - protocol: TCP
       port: 8080


### PR DESCRIPTION
## Allow Envoy Gateway ingress to i2b2 Wildfly

The i2b2 Wildfly NetworkPolicy only allowed ingress from ingress-nginx and i2b2-frontend pods. Now that i2b2 is routed through Envoy Gateway, the Envoy pods need to be allowed as well.

- Add `envoy-gateway-system` namespace with `app.kubernetes.io/managed-by: envoy-gateway` pod selector to the ingress rules
- Keeps ingress-nginx rule for backwards compatibility