### PR TITLE
fix(i2b2-wildfly,didata): support node-local-dns in network policy DNS egress

### DIFF
--- a/charts/didata/Chart.yaml
+++ b/charts/didata/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.17
+version: 0.0.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/didata/templates/ciliumnetworkpolicy.yaml
+++ b/charts/didata/templates/ciliumnetworkpolicy.yaml
@@ -31,10 +31,10 @@ spec:
   # Note: CiliumNetworkPolicy uses different format than K8s NetworkPolicy
   # For L7 WAF mode, define specific Cilium egress rules in environment-specific values
   egress:
-  # Always allow DNS resolution to kube-system
-  - toEndpoints:
-    - matchLabels:
-        k8s:io.kubernetes.pod.namespace: kube-system
+  # Always allow DNS resolution.
+  # Use kube-dns entity to auto-detect DNS infrastructure (kube-dns or node-local-dns).
+  - toEntities:
+    - kube-dns
     toPorts:
     - ports:
       - port: "53"

--- a/charts/didata/templates/networkpolicy.yaml
+++ b/charts/didata/templates/networkpolicy.yaml
@@ -24,14 +24,12 @@ spec:
   {{- if .Values.networkPolicy.egress }}
   {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
   {{- end }}
-    # Always allow DNS resolution to kube-system
-    - to:
-      - namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: kube-system
-      ports:
+    # Always allow DNS resolution (port 53 only).
+    # Some clusters use node-local-dns on a host-network link-local IP instead
+    # of kube-dns in kube-system, so we cannot restrict by namespace selector.
+    - ports:
       - protocol: UDP
-        port: 53 # Allow DNS resolution to kube-system
+        port: 53
       - protocol: TCP
-        port: 53 # Allow DNS resolution to kube-system
+        port: 53
 {{- end }}

--- a/charts/i2b2-wildfly/Chart.yaml
+++ b/charts/i2b2-wildfly/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.8
+version: 0.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/i2b2-wildfly/templates/ciliumnetworkpolicy.yaml
+++ b/charts/i2b2-wildfly/templates/ciliumnetworkpolicy.yaml
@@ -31,10 +31,10 @@ spec:
   # Note: CiliumNetworkPolicy uses different format than K8s NetworkPolicy
   # For L7 WAF mode, define specific Cilium egress rules in environment-specific values
   egress:
-  # Always allow DNS resolution to kube-system
-  - toEndpoints:
-    - matchLabels:
-        k8s:io.kubernetes.pod.namespace: kube-system
+  # Always allow DNS resolution.
+  # Use kube-dns entity to auto-detect DNS infrastructure (kube-dns or node-local-dns).
+  - toEntities:
+    - kube-dns
     toPorts:
     - ports:
       - port: "53"

--- a/charts/i2b2-wildfly/templates/networkpolicy.yaml
+++ b/charts/i2b2-wildfly/templates/networkpolicy.yaml
@@ -24,14 +24,12 @@ spec:
   {{- if .Values.networkPolicy.egress }}
   {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
   {{- end }}
-    # Always allow DNS resolution to kube-system
-    - to:
-      - namespaceSelector:
-          matchLabels:
-            kubernetes.io/metadata.name: kube-system
-      ports:
+    # Always allow DNS resolution (port 53 only).
+    # Some clusters use node-local-dns on a host-network link-local IP instead
+    # of kube-dns in kube-system, so we cannot restrict by namespace selector.
+    - ports:
       - protocol: UDP
-        port: 53 # Allow DNS resolution to kube-system
+        port: 53
       - protocol: TCP
-        port: 53 # Allow DNS resolution to kube-system
+        port: 53
 {{- end }} 


### PR DESCRIPTION
## Fix DNS egress in network policies for clusters with node-local-dns

On clusters using node-local-dns, pods resolve DNS via a host-network link-local IP (e.g. `169.254.20.10`) instead of kube-dns pods in kube-system. The previous DNS egress rules only allowed traffic to pods in kube-system, which doesn't match host-network destinations — causing `UnknownHostException` failures.

**Standard NetworkPolicy (i2b2-wildfly, didata):**
- Removed the `namespaceSelector: kube-system` restriction from the DNS egress rule
- Now allows port 53 (UDP/TCP) to any destination, scoped to the chart's pods only via `podSelector`
- Works with both kube-dns and node-local-dns setups

**CiliumNetworkPolicy (i2b2-wildfly, didata):**
- Replaced `toEndpoints` with `toEntities: ["kube-dns"]` which auto-detects the cluster's DNS infrastructure (kube-dns, node-local-dns, etc.)

**Chart versions bumped:**
- i2b2-wildfly: 0.0.8 → 0.0.9
- didata: 0.0.17 → 0.0.18