### PR TITLE
feat(gateway): dual-gateway architecture with internal/external split (gateway-helm 0.0.8, chorus-gateway 0.0.10)

### DIFF
--- a/charts/chorus-gateway/Chart.yaml
+++ b/charts/chorus-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: chorus-gateway
 description: Envoy Gateway HTTPRoutes and SecurityPolicies for internal CHORUS services
-version: 0.0.9
+version: 0.0.10
 maintainers:
   - name: iDmple
     email: nathalie.casati@chuv.ch

--- a/charts/chorus-gateway/templates/ciliumnetworkpolicies.yaml
+++ b/charts/chorus-gateway/templates/ciliumnetworkpolicies.yaml
@@ -1,38 +1,66 @@
-{{- if or .Values.routes .Values.shellServices }}
+{{- if or .Values.internal.routes .Values.internal.shellServices }}
 ---
-# Restrict ingress on all Envoy pods to cluster-internal traffic only.
+# Restrict ingress on internal gateway Envoy pods to cluster-internal traffic only.
 # fromEntities: cluster matches all pods and nodes within the cluster regardless of IP
 # masquerading, blocking external users while allowing workspace pods.
 # Adding any ingress rule triggers Cilium deny-by-default for ALL other ingress on the
 # matched pods, so every Envoy listener port must be explicitly listed here.
+# Uses owning-gateway-name label to target only the internal gateway's pods,
+# keeping the external gateway's pods unaffected.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: envoy-gateway-ingress
-  namespace: {{ .Values.gateway.namespace }}
+  name: envoy-internal-gateway-ingress
+  namespace: {{ .Values.internal.gateway.namespace }}
   labels:
     {{- include "chorus-gateway.labels" . | nindent 4 }}
 spec:
   endpointSelector:
     matchLabels:
-      app.kubernetes.io/managed-by: envoy-gateway
+      gateway.envoyproxy.io/owning-gateway-name: {{ .Values.internal.gateway.name }}
   ingress:
     - fromEntities:
         - cluster
       toPorts:
         - ports:
-            {{- if .Values.routes }}
+            {{- if .Values.internal.routes }}
             # All HTTPRoutes use gateway port 443 → Envoy remaps to 10443.
             - port: "10443"
               protocol: TCP
             {{- end }}
-            {{- range .Values.shellServices }}
+            {{- range .Values.internal.shellServices }}
             - port: {{ add .gatewayPort 10000 | toString | quote }}
               protocol: TCP
             {{- end }}
 {{- end }}
 
-{{- range .Values.shellServices }}
+{{- if .Values.external.routes }}
+---
+# Allow all ingress on external gateway Envoy pods (browsers + cluster).
+# No fromEntities restriction — the external gateway serves public traffic.
+# Adding any ingress rule triggers Cilium deny-by-default for ALL other ingress on the
+# matched pods, so the HTTPS port must be explicitly listed here.
+# Uses owning-gateway-name label to target only the external gateway's pods,
+# keeping the internal gateway's pods unaffected.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: envoy-external-gateway-ingress
+  namespace: {{ .Values.external.gateway.namespace }}
+  labels:
+    {{- include "chorus-gateway.labels" . | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      gateway.envoyproxy.io/owning-gateway-name: {{ .Values.external.gateway.name }}
+  ingress:
+    - toPorts:
+        - ports:
+            - port: "10443"
+              protocol: TCP
+{{- end }}
+
+{{- range .Values.internal.shellServices }}
 ---
 # Defense-in-depth: restrict ingress on the container port to Envoy pods only.
 # Envoy terminates the client TCP connection and opens a new one to the service pod,
@@ -54,7 +82,7 @@ spec:
     - fromEndpoints:
         - matchLabels:
             app.kubernetes.io/managed-by: envoy-gateway
-            k8s:io.kubernetes.pod.namespace: {{ $.Values.gateway.namespace | quote }}
+            k8s:io.kubernetes.pod.namespace: {{ $.Values.internal.gateway.namespace | quote }}
       toPorts:
         - ports:
             - port: {{ .containerPort | toString | quote }}

--- a/charts/chorus-gateway/templates/httproutes.yaml
+++ b/charts/chorus-gateway/templates/httproutes.yaml
@@ -1,15 +1,84 @@
-{{- range .Values.routes }}
+{{- /*
+  Internal routes — attached to the internal gateway by default.
+  - Default: parentRef is internalGateway only (workspace pods only, SecurityPolicy restricted).
+  - Dual-access (gateways: [internal, external]): single HTTPRoute with two parentRefs,
+    reachable from both workspace pods and external browsers.
+  - Path-restricted (matches: [{pathPrefix: /path}]): only forwards matching paths to the backend,
+    used to expose a subset of a service internally (e.g. backend IDP /openid-connect/).
+*/}}
+{{- range .Values.internal.routes }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ required "route.name is required" .name }}-httproute
-  namespace: {{ $.Values.gateway.namespace }}
+  namespace: {{ $.Values.internal.gateway.namespace }}
   labels:
     {{- include "chorus-gateway.labels" $ | nindent 4 }}
 spec:
   parentRefs:
-    - name: {{ $.Values.gateway.name }}
+    {{- if .gateways }}
+    {{- range .gateways }}
+    {{- if eq . "internal" }}
+    - name: {{ $.Values.internal.gateway.name }}
+    {{- else if eq . "external" }}
+    - name: {{ $.Values.external.gateway.name }}
+    {{- end }}
+    {{- end }}
+    {{- else }}
+    - name: {{ $.Values.internal.gateway.name }}
+    {{- end }}
+  hostnames:
+    - {{ required "route.hostname is required" .hostname | quote }}
+  rules:
+    {{- if .redirectPath }}
+    - matches:
+        - path:
+            type: Exact
+            value: /
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: {{ .redirectPath | quote }}
+    {{- end }}
+    {{- if .matches }}
+    {{- range .matches }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ required "match.pathPrefix is required" .pathPrefix | quote }}
+      backendRefs:
+        - name: {{ required "route.serviceName is required" $.serviceName }}
+          namespace: {{ required "route.namespace is required" $.namespace }}
+          port: {{ required "route.servicePort is required" $.servicePort }}
+    {{- end }}
+    {{- else }}
+    - backendRefs:
+        - name: {{ required "route.serviceName is required" .serviceName }}
+          namespace: {{ required "route.namespace is required" .namespace }}
+          port: {{ required "route.servicePort is required" .servicePort }}
+    {{- end }}
+{{- end }}
+
+{{- /*
+  External routes — attached to the external gateway only.
+  No SecurityPolicy restriction — accessible from external browsers.
+  Workspace pods cannot reach these (operator CNP restricts egress to internal gateway pods only).
+*/}}
+{{- range .Values.external.routes }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ required "route.name is required" .name }}-external-httproute
+  namespace: {{ $.Values.external.gateway.namespace }}
+  labels:
+    {{- include "chorus-gateway.labels" $ | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ $.Values.external.gateway.name }}
   hostnames:
     - {{ required "route.hostname is required" .hostname | quote }}
   rules:

--- a/charts/chorus-gateway/templates/httproutes.yaml
+++ b/charts/chorus-gateway/templates/httproutes.yaml
@@ -7,11 +7,12 @@
     used to expose a subset of a service internally (e.g. backend IDP /openid-connect/).
 */}}
 {{- range .Values.internal.routes }}
+{{- $routeName := required "route.name is required" .name }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: {{ required "route.name is required" .name }}-httproute
+  name: {{ $routeName }}-httproute
   namespace: {{ $.Values.internal.gateway.namespace }}
   labels:
     {{- include "chorus-gateway.labels" $ | nindent 4 }}
@@ -23,6 +24,8 @@ spec:
     - name: {{ $.Values.internal.gateway.name }}
     {{- else if eq . "external" }}
     - name: {{ $.Values.external.gateway.name }}
+    {{- else }}
+    {{- fail (printf "unknown gateway %q in route %q — must be \"internal\" or \"external\"" . $routeName) }}
     {{- end }}
     {{- end }}
     {{- else }}
@@ -32,6 +35,8 @@ spec:
     - {{ required "route.hostname is required" .hostname | quote }}
   rules:
     {{- if .redirectPath }}
+    {{- /* Redirect on exact "/" — Gateway API evaluates matches-bearing rules before
+         match-less ones, so this takes precedence over the catchall backendRefs below. */}}
     - matches:
         - path:
             type: Exact
@@ -83,6 +88,8 @@ spec:
     - {{ required "route.hostname is required" .hostname | quote }}
   rules:
     {{- if .redirectPath }}
+    {{- /* Redirect on exact "/" — Gateway API evaluates matches-bearing rules before
+         match-less ones, so this takes precedence over the catchall backendRefs below. */}}
     - matches:
         - path:
             type: Exact

--- a/charts/chorus-gateway/templates/referencegrants.yaml
+++ b/charts/chorus-gateway/templates/referencegrants.yaml
@@ -1,5 +1,5 @@
 {{- $seenNamespaces := dict }}
-{{- range .Values.routes }}
+{{- range concat .Values.internal.routes .Values.external.routes }}
 {{- if not (hasKey $seenNamespaces .namespace) }}
 {{- $_ := set $seenNamespaces .namespace true }}
 ---
@@ -14,10 +14,15 @@ spec:
   from:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
-      namespace: {{ $.Values.gateway.namespace }}
+      namespace: {{ $.Values.internal.gateway.namespace }}
+    {{- if ne $.Values.internal.gateway.namespace $.Values.external.gateway.namespace }}
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      namespace: {{ $.Values.external.gateway.namespace }}
+    {{- end }}
     - group: gateway.networking.k8s.io
       kind: TCPRoute
-      namespace: {{ $.Values.gateway.namespace }}
+      namespace: {{ $.Values.internal.gateway.namespace }}
   to:
     - group: ""
       kind: Service

--- a/charts/chorus-gateway/templates/securitypolicy.yaml
+++ b/charts/chorus-gateway/templates/securitypolicy.yaml
@@ -1,15 +1,31 @@
-{{- if .Values.routes }}
+{{- /*
+  SecurityPolicy restricts internal-only routes to pod CIDR (workspace pods only).
+  Dual-gateway routes (gateways: [internal, external]) are excluded — SecurityPolicy applies
+  per-HTTPRoute not per-parentRef, so it would block external traffic too.
+  For dual-access services, the internal gateway is protected by the CNP layer instead.
+*/}}
+{{- $internalOnlyRoutes := list }}
+{{- range .Values.internal.routes }}
+{{- $hasExternal := false }}
+{{- range .gateways }}
+{{- if eq . "external" }}{{ $hasExternal = true }}{{ end }}
+{{- end }}
+{{- if not $hasExternal }}
+{{- $internalOnlyRoutes = append $internalOnlyRoutes . }}
+{{- end }}
+{{- end }}
+{{- if $internalOnlyRoutes }}
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:
   name: workspaces-securitypolicy
-  namespace: {{ .Values.gateway.namespace }}
+  namespace: {{ .Values.internal.gateway.namespace }}
   labels:
     {{- include "chorus-gateway.labels" . | nindent 4 }}
 spec:
   targetRefs:
-    {{- range .Values.routes }}
+    {{- range $internalOnlyRoutes }}
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       name: {{ .name }}-httproute

--- a/charts/chorus-gateway/templates/securitypolicy.yaml
+++ b/charts/chorus-gateway/templates/securitypolicy.yaml
@@ -3,6 +3,8 @@
   Dual-gateway routes (gateways: [internal, external]) are excluded — SecurityPolicy applies
   per-HTTPRoute not per-parentRef, so it would block external traffic too.
   For dual-access services, the internal gateway is protected by the CNP layer instead.
+  Note: the CNP uses fromEntities: cluster which includes pods AND nodes (kubelet, kube-proxy,
+  health checks). This is slightly broader than the podCIDR SecurityPolicy (pods only).
 */}}
 {{- $internalOnlyRoutes := list }}
 {{- range .Values.internal.routes }}

--- a/charts/chorus-gateway/templates/tcproutes.yaml
+++ b/charts/chorus-gateway/templates/tcproutes.yaml
@@ -1,15 +1,15 @@
-{{- range .Values.tcpRoutes }}
+{{- range .Values.internal.tcpRoutes }}
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TCPRoute
 metadata:
   name: {{ required "tcpRoute.name is required" .name }}
-  namespace: {{ $.Values.gateway.namespace }}
+  namespace: {{ $.Values.internal.gateway.namespace }}
   labels:
     {{- include "chorus-gateway.labels" $ | nindent 4 }}
 spec:
   parentRefs:
-    - name: {{ $.Values.gateway.name }}
+    - name: {{ $.Values.internal.gateway.name }}
       sectionName: tcp-{{ required "tcpRoute.gatewayPort is required" .gatewayPort | toString }}
   rules:
     - backendRefs:

--- a/charts/chorus-gateway/values.yaml
+++ b/charts/chorus-gateway/values.yaml
@@ -7,53 +7,104 @@
 # Derive the cluster supernet by keeping the first two octets and using /16 (e.g. 192.168.0.0/16).
 podCIDR: ""
 
-# Gateway reference — all HTTPRoutes attach to this Gateway.
-gateway:
-  # Must match the Gateway metadata.name in the gateway-helm chart.
-  name: chorus-gateway
-  namespace: envoy-gateway-system
+# Internal gateway — workspace pods only. SecurityPolicy restricts routes to podCIDR.
+# The envoy-internal-gateway-ingress CiliumNetworkPolicy restricts ingress on the internal
+# gateway's Envoy pods to cluster-internal traffic only (fromEntities: cluster), blocking
+# external users. Adding any ingress rule triggers Cilium deny-by-default for ALL other
+# ingress on the matched pods, so every Envoy listener port must be explicitly listed.
+# Gateway name must match the Gateway metadata.name in the gateway-helm chart.
+internal:
+  gateway:
+    name: chorus-internal-gateway
+    namespace: envoy-gateway-system
 
-# Internal service routes — each entry creates an HTTPRoute and ReferenceGrant.
-# All routes are restricted to pod CIDR only via SecurityPolicy.
-# Must be set in environment values.
-#
-# Example:
-#   routes:
-#     - name: gitlab
-#       hostname: gitlab.internal.chorus-tre.local
-#       namespace: gitlab
-#       serviceName: my-release-webservice-default
-#       servicePort: 8181
-#     - name: i2b2
-#       hostname: i2b2.internal.chorus-tre.local
-#       namespace: i2b2
-#       serviceName: my-release-i2b2-frontend
-#       servicePort: 80
-#       redirectPath: /webclient
-routes: []
+  # HTTPRoutes (parentRef: internal gateway) and ReferenceGrants.
+  # All routes are restricted to pod CIDR only via SecurityPolicy.
+  # Must be set in environment values.
+  #
+  # Optional fields:
+  #   matches: path-restricted route (e.g. expose only /openid-connect/ internally)
+  #   gateways: [internal, external] creates a single HTTPRoute with two parentRefs (dual-access).
+  #     Dual-access routes are excluded from the SecurityPolicy (it applies per-HTTPRoute not
+  #     per-parentRef — would block external traffic too). The internal gateway is protected
+  #     by the CiliumNetworkPolicy layer instead.
+  #
+  # Example:
+  #   routes:
+  #     - name: gitlab
+  #       hostname: gitlab.internal.chorus-tre.local
+  #       namespace: gitlab
+  #       serviceName: my-release-webservice-default
+  #       servicePort: 8181
+  #     - name: i2b2
+  #       hostname: i2b2.internal.chorus-tre.local
+  #       namespace: i2b2
+  #       serviceName: my-release-i2b2-frontend
+  #       servicePort: 80
+  #       redirectPath: /webclient
+  #     - name: backend-idp
+  #       hostname: backend.chorus-tre.local
+  #       namespace: backend
+  #       serviceName: backend
+  #       servicePort: 5000
+  #       matches:
+  #         - pathPrefix: /openid-connect
+  #     - name: keycloak
+  #       hostname: auth.chorus-tre.local
+  #       namespace: keycloak
+  #       serviceName: keycloak
+  #       servicePort: 8080
+  #       gateways: [internal, external]
+  routes: []
 
-# TCP service routes — each entry creates a TCPRoute forwarding gatewayPort to the service.
-# gatewayPort must match a tcp.listeners entry in gateway-helm.
-#
-# tcpRoutes:
-#   - name: gitlab-shell
-#     namespace: gitlab
-#     serviceName: chorus-int-gitlab-gitlab-shell
-#     servicePort: 22
-#     gatewayPort: 22
-tcpRoutes: []
+  # TCPRoutes (parentRef: internal gateway) forwarding gatewayPort to the service.
+  # gatewayPort must match a tcpListeners entry in the gateway-helm chart
+  # (Envoy Gateway remaps it to gatewayPort+10000 internally, e.g. 22 → 10022).
+  #
+  # Example:
+  #   tcpRoutes:
+  #     - name: gitlab-shell
+  #       namespace: gitlab
+  #       serviceName: chorus-int-gitlab-gitlab-shell
+  #       servicePort: 22
+  #       gatewayPort: 22
+  tcpRoutes: []
 
-# Shell services — each entry creates a CiliumNetworkPolicy restricting ingress on the
-# service container port to Envoy pods only (defense-in-depth).
-# A single envoy-gateway-ingress CNP (generated if routes or shellServices exist) restricts
-# all Envoy pod ingress to cluster-internal traffic, blocking external users.
-# gatewayPort must match a tcp.listeners entry in gateway-helm (Envoy remaps it to gatewayPort+10000).
-#
-# shellServices:
-#   - name: gitlab-shell
-#     namespace: gitlab
-#     podSelector:
-#       app: gitlab-shell
-#     containerPort: 2222
-#     gatewayPort: 22
-shellServices: []
+  # Shell services — each entry creates a CiliumNetworkPolicy restricting ingress on the
+  # service container port to Envoy pods only (defense-in-depth).
+  # Envoy terminates the client TCP connection and opens a new one to the service pod,
+  # so the source IP at the service pod is the Envoy pod IP, not the original client IP.
+  # gatewayPort must match a tcpListeners entry in gateway-helm (Envoy remaps it to gatewayPort+10000).
+  #
+  # Example:
+  #   shellServices:
+  #     - name: gitlab-shell
+  #       namespace: gitlab
+  #       podSelector:
+  #         app: gitlab-shell
+  #       containerPort: 2222
+  #       gatewayPort: 22
+  shellServices: []
+
+# External gateway — accessible from external browsers. No SecurityPolicy restriction.
+# Workspace pods cannot reach these (operator CNP restricts egress to internal gateway pods only).
+# The envoy-external-gateway-ingress CiliumNetworkPolicy allows all ingress on the external
+# gateway's Envoy pods (both cluster and world traffic) on port 10443.
+# Gateway name must match the Gateway metadata.name in the gateway-helm chart.
+external:
+  gateway:
+    name: chorus-external-gateway
+    namespace: envoy-gateway-system
+
+  # HTTPRoutes (parentRef: external gateway) and ReferenceGrants.
+  # No SecurityPolicy restriction — accessible from browsers.
+  # Must be set in environment values.
+  #
+  # Example:
+  #   routes:
+  #     - name: juicefs-dashboard
+  #       hostname: juicefs-dashboard.chorus-tre.local
+  #       namespace: kube-system
+  #       serviceName: juicefs-csi-driver-dashboard
+  #       servicePort: 8080
+  routes: []

--- a/charts/chorus-gateway/values.yaml
+++ b/charts/chorus-gateway/values.yaml
@@ -98,6 +98,7 @@ external:
 
   # HTTPRoutes (parentRef: external gateway) and ReferenceGrants.
   # No SecurityPolicy restriction — accessible from browsers.
+  # Supports redirectPath but not matches or gateways (dual-access is via internal.routes only).
   # Must be set in environment values.
   #
   # Example:

--- a/charts/gateway-helm/Chart.yaml
+++ b/charts/gateway-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: The Helm chart for Envoy Gateway
 name: gateway-helm
-version: 0.0.7
+version: 0.0.8
 dependencies:
   - name: gateway-helm
     version: v1.4.1

--- a/charts/gateway-helm/templates/gateway.yaml
+++ b/charts/gateway-helm/templates/gateway.yaml
@@ -1,15 +1,17 @@
-{{- if .Values.tls.listeners }}
+{{- range $key, $gw := .Values.gateways }}
+{{- if $gw.listeners }}
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: chorus-gateway
+  name: {{ required (print "gateways." $key ".name is required") $gw.name }}
   namespace: envoy-gateway-system
   annotations:
-    cert-manager.io/cluster-issuer: {{ .Values.tls.clusterIssuer | quote }}
+    cert-manager.io/cluster-issuer: {{ $.Values.tls.clusterIssuer | quote }}
 spec:
   gatewayClassName: eg
   listeners:
-    {{- range .Values.tls.listeners }}
+    {{- range $gw.listeners }}
     {{- /* Name: use explicit .name if set, otherwise derived from hostname (dots → dashes, * → wildcard, truncated to 63 chars).
          Hostnames that differ only by characters mapping to "-" would collide — set an explicit .name per listener to disambiguate. */}}
     - name: {{ .name | default (required "listener.hostname is required" .hostname | replace "." "-" | replace "*" "wildcard" | trunc 63) }}
@@ -24,10 +26,9 @@ spec:
             name: {{ required "listener.secretName is required" .secretName | quote }}
       allowedRoutes:
         namespaces:
-          # Allow HTTPRoutes from any namespace — service charts deploy routes in their own namespaces.
           from: All
     {{- end }}
-    {{- range .Values.tcp.listeners }}
+    {{- range $gw.tcpListeners }}
     - name: {{ .name | default (print "tcp-" .port) }}
       port: {{ .port }}
       protocol: TCP
@@ -35,4 +36,5 @@ spec:
         namespaces:
           from: All
     {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/gateway-helm/templates/gateway.yaml
+++ b/charts/gateway-helm/templates/gateway.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ required (print "gateways." $key ".name is required") $gw.name }}
   namespace: envoy-gateway-system
   annotations:
-    cert-manager.io/cluster-issuer: {{ $.Values.tls.clusterIssuer | quote }}
+    cert-manager.io/cluster-issuer: {{ $gw.clusterIssuer | default $.Values.tls.clusterIssuer | quote }}
 spec:
   gatewayClassName: eg
   listeners:
@@ -26,6 +26,7 @@ spec:
             name: {{ required "listener.secretName is required" .secretName | quote }}
       allowedRoutes:
         namespaces:
+          # Allow HTTPRoutes from any namespace — service charts deploy routes in their own namespaces.
           from: All
     {{- end }}
     {{- range $gw.tcpListeners }}

--- a/charts/gateway-helm/values.yaml
+++ b/charts/gateway-helm/values.yaml
@@ -11,8 +11,8 @@ gateway-helm:
 #   kubectl get gateway chorus-gateway -n envoy-gateway-system -o jsonpath='{.status.addresses[0].value}'
 
 tls:
-  # ClusterIssuer used by cert-manager to provision TLS certificates.
-  # Applies to all gateways — shared across internal and external.
+  # Default ClusterIssuer used by cert-manager to provision TLS certificates.
+  # Can be overridden per-gateway with gateways.<key>.clusterIssuer.
   # Mixing HTTP01 and DNS01 on a single Gateway is not supported.
   clusterIssuer: letsencrypt-prod
 
@@ -45,6 +45,7 @@ tls:
 #         - port: 22
 #     external:
 #       name: chorus-external-gateway
+#       # clusterIssuer: letsencrypt-prod-http01  # optional per-gateway override
 #       listeners:
 #         - hostname: "*.chorus-tre.local"
 #           secretName: external-tls

--- a/charts/gateway-helm/values.yaml
+++ b/charts/gateway-helm/values.yaml
@@ -12,29 +12,40 @@ gateway-helm:
 
 tls:
   # ClusterIssuer used by cert-manager to provision TLS certificates.
-  # Applies to all listeners — mixing HTTP01 and DNS01 on a single Gateway is not supported.
+  # Applies to all gateways — shared across internal and external.
+  # Mixing HTTP01 and DNS01 on a single Gateway is not supported.
   clusterIssuer: letsencrypt-prod
 
-  # One entry per hostname — cert-manager provisions one Certificate per listener.
-  # Must be set in environment values.
-  #
-  # Option A — per-hostname certs (HTTP01, no DNS access required):
-  #   listeners:
-  #     - hostname: gitlab.chorus-tre.local
-  #       secretName: gitlab-tls
-  #     - hostname: keycloak.chorus-tre.local
-  #       secretName: keycloak-tls
-  #
-  # Option B — wildcard cert (DNS01 required, e.g. Cloudflare):
-  #   listeners:
-  #     - hostname: "*.chorus-tre.local"
-  #       secretName: wildcard-tls
-  listeners: []
-
-# TCP listeners (e.g. port 22 for GitLab SSH) — must be set in environment values.
+# Each key creates a separate Gateway resource with its own Envoy Deployment + LoadBalancer.
+# Each gateway gets its own MetalLB VIP automatically.
+# Must be set in environment values.
 #
-# tcp:
-#   listeners:
+# Listeners: one entry per hostname — cert-manager provisions one Certificate per listener.
+#   Option A — per-hostname certs (HTTP01, no DNS access required):
+#     listeners:
+#       - hostname: gitlab.chorus-tre.local
+#         secretName: gitlab-tls
+#   Option B — wildcard cert (DNS01 required, e.g. Cloudflare):
+#     listeners:
+#       - hostname: "*.chorus-tre.local"
+#         secretName: wildcard-tls
+#
+# TCP listeners (e.g. port 22 for GitLab SSH):
+#   tcpListeners:
 #     - port: 22
-tcp:
-  listeners: []
+#
+# Example:
+#   gateways:
+#     internal:
+#       name: chorus-internal-gateway
+#       listeners:
+#         - hostname: "*.internal.chorus-tre.local"
+#           secretName: internal-tls
+#       tcpListeners:
+#         - port: 22
+#     external:
+#       name: chorus-external-gateway
+#       listeners:
+#         - hostname: "*.chorus-tre.local"
+#           secretName: external-tls
+gateways: {}


### PR DESCRIPTION
## Dual-gateway architecture

Refactors the gateway infrastructure to support two Envoy Gateways:
- **chorus-internal-gateway** (renamed from chorus-gateway) — workspace pods only, SecurityPolicy restricts to podCIDR, CNP blocks external traffic
- **chorus-external-gateway** (new) — external browsers, no SecurityPolicy restriction, CNP allows all ingress on port 10443

### gateway-helm (0.0.8)
- Refactor single Gateway to a `gateways` map — each key creates a separate Gateway resource with its own listeners, LB, and MetalLB VIP
- Rename existing gateway from `chorus-gateway` to `chorus-internal-gateway`
- `tls.listeners` / `tcp.listeners` moved under `gateways.<key>.listeners` / `gateways.<key>.tcpListeners`

### chorus-gateway (0.0.10)
- Rename `routes` to `internal.routes`, `gateway` to `internal.gateway`
- Add `external.gateway` and `external.routes` for public services
- Add path-match support (`matches: [{pathPrefix: /path}]`) for exposing subsets of a service internally
- Add dual-access support (`gateways: [internal, external]`) for services reachable from both gateways
- SecurityPolicy excludes dual-gateway routes (protected by CNP layer instead)
- Split CiliumNetworkPolicy per gateway using `gateway.envoyproxy.io/owning-gateway-name` label
- ReferenceGrants cover both internal and external route namespaces

### Post-deploy cleanup
- Delete old Gateway: `kubectl delete gateway chorus-gateway -n envoy-gateway-system`
- Delete old CNP: `kubectl delete ciliumnetworkpolicy envoy-gateway-ingress -n envoy-gateway-system`
- Point `juicefs-dashboard.int.chorus-tre.ch` DNS to the new external gateway LB IP