### PR TITLE
fix(juicefs-csi-driver): add NetworkPolicy allowing Envoy Gateway to reach dashboard (0.0.15)

### DIFF
--- a/charts/juicefs-csi-driver/Chart.yaml
+++ b/charts/juicefs-csi-driver/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: juicefs-csi-driver
 description: A Helm chart for JuiceFS CSI Driver.
-version: 0.0.14
+version: 0.0.15
 dependencies:
   - name: juicefs-csi-driver
     version: 0.31.1

--- a/charts/juicefs-csi-driver/templates/networkpolicy.yaml
+++ b/charts/juicefs-csi-driver/templates/networkpolicy.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values "juicefs-csi-driver" "dashboard" "enabled") }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -20,3 +21,4 @@ spec:
     ports:
     - protocol: TCP
       port: 8088
+{{- end }}

--- a/charts/juicefs-csi-driver/templates/networkpolicy.yaml
+++ b/charts/juicefs-csi-driver/templates/networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: juicefs-csi-dashboard
+  namespace: {{ .Release.Namespace | quote }}
+spec:
+  podSelector:
+    matchLabels:
+      app: juicefs-csi-dashboard
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: envoy-gateway-system
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/managed-by: envoy-gateway
+    ports:
+    - protocol: TCP
+      port: 8088


### PR DESCRIPTION
## Add NetworkPolicy for JuiceFS Dashboard

The `kube-system` namespace has an RKE2 default-deny ingress policy (`default-network-policy`) that blocks all cross-namespace traffic. The JuiceFS Dashboard needs Envoy Gateway pods to reach it on port 8088.

- Add NetworkPolicy allowing ingress from `envoy-gateway-system` Envoy pods to the dashboard pod on port 8088