### PR TITLE
feat(gateway): single gateway with per-route SecurityPolicy (gateway-helm 0.0.9, chorus-gateway 0.0.11)

### DIFF
--- a/charts/chorus-gateway/Chart.yaml
+++ b/charts/chorus-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: chorus-gateway
-description: Envoy Gateway HTTPRoutes and SecurityPolicies for internal CHORUS services
-version: 0.0.10
+description: Envoy Gateway HTTPRoutes and SecurityPolicies for CHORUS services
+version: 0.0.11
 maintainers:
   - name: iDmple
     email: nathalie.casati@chuv.ch

--- a/charts/chorus-gateway/templates/ciliumnetworkpolicies.yaml
+++ b/charts/chorus-gateway/templates/ciliumnetworkpolicies.yaml
@@ -1,66 +1,36 @@
-{{- if or .Values.internal.routes .Values.internal.shellServices }}
+{{- if or .Values.internalRoutes .Values.externalRoutes .Values.openRoutes .Values.internalShellServices }}
 ---
-# Restrict ingress on internal gateway Envoy pods to cluster-internal traffic only.
-# fromEntities: cluster matches all pods and nodes within the cluster regardless of IP
-# masquerading, blocking external users while allowing workspace pods.
+# Allow ingress on the Envoy Gateway pods from both cluster and external traffic.
+# Access control is enforced per-route via SecurityPolicy (internal: allow podCIDR,
+# external: deny podCIDR, open: no restriction).
 # Adding any ingress rule triggers Cilium deny-by-default for ALL other ingress on the
 # matched pods, so every Envoy listener port must be explicitly listed here.
-# Uses owning-gateway-name label to target only the internal gateway's pods,
-# keeping the external gateway's pods unaffected.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
-  name: envoy-internal-gateway-ingress
-  namespace: {{ .Values.internal.gateway.namespace }}
+  name: envoy-gateway-ingress
+  namespace: {{ .Values.gateway.namespace }}
   labels:
     {{- include "chorus-gateway.labels" . | nindent 4 }}
 spec:
   endpointSelector:
     matchLabels:
-      gateway.envoyproxy.io/owning-gateway-name: {{ .Values.internal.gateway.name }}
+      app.kubernetes.io/managed-by: envoy-gateway
   ingress:
-    - fromEntities:
-        - cluster
-      toPorts:
+    - toPorts:
         - ports:
-            {{- if .Values.internal.routes }}
+            {{- if or .Values.internalRoutes .Values.externalRoutes .Values.openRoutes }}
             # All HTTPRoutes use gateway port 443 → Envoy remaps to 10443.
             - port: "10443"
               protocol: TCP
             {{- end }}
-            {{- range .Values.internal.shellServices }}
+            {{- range .Values.internalShellServices }}
             - port: {{ add .gatewayPort 10000 | toString | quote }}
               protocol: TCP
             {{- end }}
 {{- end }}
 
-{{- if .Values.external.routes }}
----
-# Allow all ingress on external gateway Envoy pods (browsers + cluster).
-# No fromEntities restriction — the external gateway serves public traffic.
-# Adding any ingress rule triggers Cilium deny-by-default for ALL other ingress on the
-# matched pods, so the HTTPS port must be explicitly listed here.
-# Uses owning-gateway-name label to target only the external gateway's pods,
-# keeping the internal gateway's pods unaffected.
-apiVersion: cilium.io/v2
-kind: CiliumNetworkPolicy
-metadata:
-  name: envoy-external-gateway-ingress
-  namespace: {{ .Values.external.gateway.namespace }}
-  labels:
-    {{- include "chorus-gateway.labels" . | nindent 4 }}
-spec:
-  endpointSelector:
-    matchLabels:
-      gateway.envoyproxy.io/owning-gateway-name: {{ .Values.external.gateway.name }}
-  ingress:
-    - toPorts:
-        - ports:
-            - port: "10443"
-              protocol: TCP
-{{- end }}
-
-{{- range .Values.internal.shellServices }}
+{{- range .Values.internalShellServices }}
 ---
 # Defense-in-depth: restrict ingress on the container port to Envoy pods only.
 # Envoy terminates the client TCP connection and opens a new one to the service pod,
@@ -82,7 +52,7 @@ spec:
     - fromEndpoints:
         - matchLabels:
             app.kubernetes.io/managed-by: envoy-gateway
-            k8s:io.kubernetes.pod.namespace: {{ $.Values.internal.gateway.namespace | quote }}
+            k8s:io.kubernetes.pod.namespace: {{ $.Values.gateway.namespace | quote }}
       toPorts:
         - ports:
             - port: {{ .containerPort | toString | quote }}

--- a/charts/chorus-gateway/templates/httproutes.yaml
+++ b/charts/chorus-gateway/templates/httproutes.yaml
@@ -1,36 +1,20 @@
 {{- /*
-  Internal routes — attached to the internal gateway by default.
-  - Default: parentRef is internalGateway only (workspace pods only, SecurityPolicy restricted).
-  - Dual-access (gateways: [internal, external]): single HTTPRoute with two parentRefs,
-    reachable from both workspace pods and external browsers.
-  - Path-restricted (matches: [{pathPrefix: /path}]): only forwards matching paths to the backend,
-    used to expose a subset of a service internally (e.g. backend IDP /openid-connect/).
+  Internal routes — workspace pods only (SecurityPolicy allows podCIDR).
+  Optional: matches (path-restricted, e.g. only /openid-connect/ internally).
 */}}
-{{- range .Values.internal.routes }}
-{{- $routeName := required "route.name is required" .name }}
+{{- range .Values.internalRoutes }}
+{{- $route := . }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: {{ $routeName }}-httproute
-  namespace: {{ $.Values.internal.gateway.namespace }}
+  name: {{ required "route.name is required" .name }}-internal-httproute
+  namespace: {{ $.Values.gateway.namespace }}
   labels:
     {{- include "chorus-gateway.labels" $ | nindent 4 }}
 spec:
   parentRefs:
-    {{- if .gateways }}
-    {{- range .gateways }}
-    {{- if eq . "internal" }}
-    - name: {{ $.Values.internal.gateway.name }}
-    {{- else if eq . "external" }}
-    - name: {{ $.Values.external.gateway.name }}
-    {{- else }}
-    {{- fail (printf "unknown gateway %q in route %q — must be \"internal\" or \"external\"" . $routeName) }}
-    {{- end }}
-    {{- end }}
-    {{- else }}
-    - name: {{ $.Values.internal.gateway.name }}
-    {{- end }}
+    - name: {{ $.Values.gateway.name }}
   hostnames:
     - {{ required "route.hostname is required" .hostname | quote }}
   rules:
@@ -55,9 +39,9 @@ spec:
             type: PathPrefix
             value: {{ required "match.pathPrefix is required" .pathPrefix | quote }}
       backendRefs:
-        - name: {{ required "route.serviceName is required" $.serviceName }}
-          namespace: {{ required "route.namespace is required" $.namespace }}
-          port: {{ required "route.servicePort is required" $.servicePort }}
+        - name: {{ required "route.serviceName is required" $route.serviceName }}
+          namespace: {{ required "route.namespace is required" $route.namespace }}
+          port: {{ required "route.servicePort is required" $route.servicePort }}
     {{- end }}
     {{- else }}
     - backendRefs:
@@ -68,22 +52,60 @@ spec:
 {{- end }}
 
 {{- /*
-  External routes — attached to the external gateway only.
-  No SecurityPolicy restriction — accessible from external browsers.
-  Workspace pods cannot reach these (operator CNP restricts egress to internal gateway pods only).
+  External routes — browsers only (SecurityPolicy denies podCIDR).
+  Workspace pods get 403.
 */}}
-{{- range .Values.external.routes }}
+{{- range .Values.externalRoutes }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: {{ required "route.name is required" .name }}-external-httproute
-  namespace: {{ $.Values.external.gateway.namespace }}
+  namespace: {{ $.Values.gateway.namespace }}
   labels:
     {{- include "chorus-gateway.labels" $ | nindent 4 }}
 spec:
   parentRefs:
-    - name: {{ $.Values.external.gateway.name }}
+    - name: {{ $.Values.gateway.name }}
+  hostnames:
+    - {{ required "route.hostname is required" .hostname | quote }}
+  rules:
+    {{- if .redirectPath }}
+    {{- /* Redirect on exact "/" — Gateway API evaluates matches-bearing rules before
+         match-less ones, so this takes precedence over the catchall backendRefs below. */}}
+    - matches:
+        - path:
+            type: Exact
+            value: /
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: {{ .redirectPath | quote }}
+    {{- end }}
+    - backendRefs:
+        - name: {{ required "route.serviceName is required" .serviceName }}
+          namespace: {{ required "route.namespace is required" .namespace }}
+          port: {{ required "route.servicePort is required" .servicePort }}
+{{- end }}
+
+{{- /*
+  Open routes — accessible from both workspace pods and external browsers.
+  No SecurityPolicy restriction.
+*/}}
+{{- range .Values.openRoutes }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ required "route.name is required" .name }}-open-httproute
+  namespace: {{ $.Values.gateway.namespace }}
+  labels:
+    {{- include "chorus-gateway.labels" $ | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ $.Values.gateway.name }}
   hostnames:
     - {{ required "route.hostname is required" .hostname | quote }}
   rules:

--- a/charts/chorus-gateway/templates/referencegrants.yaml
+++ b/charts/chorus-gateway/templates/referencegrants.yaml
@@ -1,5 +1,5 @@
 {{- $seenNamespaces := dict }}
-{{- range concat .Values.internal.routes .Values.external.routes }}
+{{- range concat .Values.internalRoutes .Values.externalRoutes .Values.openRoutes }}
 {{- if not (hasKey $seenNamespaces .namespace) }}
 {{- $_ := set $seenNamespaces .namespace true }}
 ---
@@ -14,15 +14,10 @@ spec:
   from:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
-      namespace: {{ $.Values.internal.gateway.namespace }}
-    {{- if ne $.Values.internal.gateway.namespace $.Values.external.gateway.namespace }}
-    - group: gateway.networking.k8s.io
-      kind: HTTPRoute
-      namespace: {{ $.Values.external.gateway.namespace }}
-    {{- end }}
+      namespace: {{ $.Values.gateway.namespace }}
     - group: gateway.networking.k8s.io
       kind: TCPRoute
-      namespace: {{ $.Values.internal.gateway.namespace }}
+      namespace: {{ $.Values.gateway.namespace }}
   to:
     - group: ""
       kind: Service

--- a/charts/chorus-gateway/templates/securitypolicy.yaml
+++ b/charts/chorus-gateway/templates/securitypolicy.yaml
@@ -1,42 +1,67 @@
 {{- /*
-  SecurityPolicy restricts internal-only routes to pod CIDR (workspace pods only).
-  Dual-gateway routes (gateways: [internal, external]) are excluded — SecurityPolicy applies
-  per-HTTPRoute not per-parentRef, so it would block external traffic too.
-  For dual-access services, the internal gateway is protected by the CNP layer instead.
-  Note: the CNP uses fromEntities: cluster which includes pods AND nodes (kubelet, kube-proxy,
-  health checks). This is slightly broader than the podCIDR SecurityPolicy (pods only).
+  Internal SecurityPolicy — allows podCIDR only (workspace pods).
+  External browsers get 403.
+  Targets internal HTTPRoutes and TCPRoutes.
 */}}
-{{- $internalOnlyRoutes := list }}
-{{- range .Values.internal.routes }}
-{{- $hasExternal := false }}
-{{- range .gateways }}
-{{- if eq . "external" }}{{ $hasExternal = true }}{{ end }}
-{{- end }}
-{{- if not $hasExternal }}
-{{- $internalOnlyRoutes = append $internalOnlyRoutes . }}
-{{- end }}
-{{- end }}
-{{- if $internalOnlyRoutes }}
+{{- if or .Values.internalRoutes .Values.internalTcpRoutes }}
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:
-  name: workspaces-securitypolicy
-  namespace: {{ .Values.internal.gateway.namespace }}
+  name: internal-securitypolicy
+  namespace: {{ .Values.gateway.namespace }}
   labels:
     {{- include "chorus-gateway.labels" . | nindent 4 }}
 spec:
   targetRefs:
-    {{- range $internalOnlyRoutes }}
+    {{- range .Values.internalRoutes }}
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
-      name: {{ .name }}-httproute
+      name: {{ .name }}-internal-httproute
+    {{- end }}
+    {{- range .Values.internalTcpRoutes }}
+    - group: gateway.networking.k8s.io
+      kind: TCPRoute
+      name: {{ .name }}
     {{- end }}
   authorization:
     defaultAction: Deny
     rules:
-      - action: Allow
+      - name: allow-workspace-pods
+        action: Allow
         principal:
           clientCIDRs:
             - {{ required "podCIDR must be set to match the cluster's pod CIDR" .Values.podCIDR | quote }}
 {{- end }}
+
+{{- /*
+  External SecurityPolicy — denies podCIDR (workspace pods get 403).
+  External browsers are allowed (defaultAction: Allow).
+*/}}
+{{- if .Values.externalRoutes }}
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: external-securitypolicy
+  namespace: {{ .Values.gateway.namespace }}
+  labels:
+    {{- include "chorus-gateway.labels" . | nindent 4 }}
+spec:
+  targetRefs:
+    {{- range .Values.externalRoutes }}
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ .name }}-external-httproute
+    {{- end }}
+  authorization:
+    defaultAction: Allow
+    rules:
+      - name: deny-workspace-pods
+        action: Deny
+        principal:
+          clientCIDRs:
+            - {{ required "podCIDR must be set to match the cluster's pod CIDR" .Values.podCIDR | quote }}
+{{- end }}
+
+{{- /* Open routes have no SecurityPolicy — accessible from everyone. */}}

--- a/charts/chorus-gateway/templates/securitypolicy.yaml
+++ b/charts/chorus-gateway/templates/securitypolicy.yaml
@@ -1,6 +1,6 @@
 {{- /*
   Internal SecurityPolicy — allows podCIDR only (workspace pods).
-  External browsers get 403.
+  External clients are rejected (403 for HTTP routes, L4 connection close for TCP routes).
   Targets internal HTTPRoutes and TCPRoutes.
 */}}
 {{- if or .Values.internalRoutes .Values.internalTcpRoutes }}

--- a/charts/chorus-gateway/templates/tcproutes.yaml
+++ b/charts/chorus-gateway/templates/tcproutes.yaml
@@ -1,15 +1,15 @@
-{{- range .Values.internal.tcpRoutes }}
+{{- range .Values.internalTcpRoutes }}
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TCPRoute
 metadata:
   name: {{ required "tcpRoute.name is required" .name }}
-  namespace: {{ $.Values.internal.gateway.namespace }}
+  namespace: {{ $.Values.gateway.namespace }}
   labels:
     {{- include "chorus-gateway.labels" $ | nindent 4 }}
 spec:
   parentRefs:
-    - name: {{ $.Values.internal.gateway.name }}
+    - name: {{ $.Values.gateway.name }}
       sectionName: tcp-{{ required "tcpRoute.gatewayPort is required" .gatewayPort | toString }}
   rules:
     - backendRefs:

--- a/charts/chorus-gateway/values.yaml
+++ b/charts/chorus-gateway/values.yaml
@@ -48,6 +48,10 @@ internalRoutes: []
 #
 # Example:
 #   externalRoutes:
+#     # Full backend API — browsers only. Combine with the backend-idp internalRoute above
+#     # to gate /openid-connect/ to workspace pods while keeping the rest browser-only.
+#     # Same hostname, different paths, different SecurityPolicies — Gateway API evaluates
+#     # the more specific pathPrefix first.
 #     - name: backend
 #       hostname: backend.chorus-tre.local
 #       namespace: backend

--- a/charts/chorus-gateway/values.yaml
+++ b/charts/chorus-gateway/values.yaml
@@ -1,111 +1,106 @@
-# Cluster pod CIDR — used in SecurityPolicy to restrict access to workspace pods only.
-# Not used for CiliumNetworkPolicies (those use fromEntities: cluster instead of CIDR).
-# Must match the value set in gateway-helm.
+# Cluster pod CIDR — used in SecurityPolicy to control per-route access.
+# Internal routes: Allow podCIDR only (workspace pods). External routes: Deny podCIDR (browsers only).
+# With externalTrafficPolicy: Local, SecurityPolicy clientCIDRs sees real source IPs.
 # Must be set in environment values.
 # To find it: kubectl get nodes -o jsonpath='{.items[*].spec.podCIDR}'
 # Each node shows its /24 subnet (e.g. 192.168.0.0/24, 192.168.1.0/24).
 # Derive the cluster supernet by keeping the first two octets and using /16 (e.g. 192.168.0.0/16).
 podCIDR: ""
 
-# Internal gateway — workspace pods only. SecurityPolicy restricts routes to podCIDR.
-# The envoy-internal-gateway-ingress CiliumNetworkPolicy restricts ingress on the internal
-# gateway's Envoy pods to cluster-internal traffic only (fromEntities: cluster), blocking
-# external users. Adding any ingress rule triggers Cilium deny-by-default for ALL other
-# ingress on the matched pods, so every Envoy listener port must be explicitly listed.
-# Gateway name must match the Gateway metadata.name in the gateway-helm chart.
-internal:
-  gateway:
-    name: chorus-internal-gateway
-    namespace: envoy-gateway-system
+# Gateway reference — must match the Gateway metadata.name in the gateway-helm chart.
+gateway:
+  name: chorus-gateway
+  namespace: envoy-gateway-system
 
-  # HTTPRoutes (parentRef: internal gateway) and ReferenceGrants.
-  # All routes are restricted to pod CIDR only via SecurityPolicy.
-  # Must be set in environment values.
-  #
-  # Optional fields:
-  #   matches: path-restricted route (e.g. expose only /openid-connect/ internally)
-  #   gateways: [internal, external] creates a single HTTPRoute with two parentRefs (dual-access).
-  #     Dual-access routes are excluded from the SecurityPolicy (it applies per-HTTPRoute not
-  #     per-parentRef — would block external traffic too). The internal gateway is protected
-  #     by the CiliumNetworkPolicy layer instead.
-  #
-  # Example:
-  #   routes:
-  #     - name: gitlab
-  #       hostname: gitlab.internal.chorus-tre.local
-  #       namespace: gitlab
-  #       serviceName: my-release-webservice-default
-  #       servicePort: 8181
-  #     - name: i2b2
-  #       hostname: i2b2.internal.chorus-tre.local
-  #       namespace: i2b2
-  #       serviceName: my-release-i2b2-frontend
-  #       servicePort: 80
-  #       redirectPath: /webclient
-  #     - name: backend-idp
-  #       hostname: backend.chorus-tre.local
-  #       namespace: backend
-  #       serviceName: backend
-  #       servicePort: 5000
-  #       matches:
-  #         - pathPrefix: /openid-connect
-  #     - name: keycloak
-  #       hostname: auth.chorus-tre.local
-  #       namespace: keycloak
-  #       serviceName: keycloak
-  #       servicePort: 8080
-  #       gateways: [internal, external]
-  routes: []
+# Internal routes — accessible from workspace pods only (SecurityPolicy allows podCIDR).
+# External browsers get 403.
+# Each entry creates an HTTPRoute and ReferenceGrant.
+# Must be set in environment values.
+#
+# Optional: matches (path-restricted route, e.g. expose only /openid-connect/ internally).
+#
+# Example:
+#   internalRoutes:
+#     - name: gitlab
+#       hostname: gitlab.chorus-tre.local
+#       namespace: gitlab
+#       serviceName: gitlab-webservice-default
+#       servicePort: 8181
+#     - name: i2b2
+#       hostname: i2b2.chorus-tre.local
+#       namespace: i2b2
+#       serviceName: i2b2-frontend
+#       servicePort: 80
+#       redirectPath: /webclient
+#     - name: backend-idp
+#       hostname: backend.chorus-tre.local
+#       namespace: backend
+#       serviceName: backend
+#       servicePort: 5000
+#       matches:
+#         - pathPrefix: /openid-connect
+internalRoutes: []
 
-  # TCPRoutes (parentRef: internal gateway) forwarding gatewayPort to the service.
-  # gatewayPort must match a tcpListeners entry in the gateway-helm chart
-  # (Envoy Gateway remaps it to gatewayPort+10000 internally, e.g. 22 → 10022).
-  #
-  # Example:
-  #   tcpRoutes:
-  #     - name: gitlab-shell
-  #       namespace: gitlab
-  #       serviceName: chorus-int-gitlab-gitlab-shell
-  #       servicePort: 22
-  #       gatewayPort: 22
-  tcpRoutes: []
+# External routes — accessible from external browsers only (SecurityPolicy denies podCIDR).
+# Workspace pods get 403.
+# Each entry creates an HTTPRoute and ReferenceGrant.
+# Must be set in environment values.
+#
+# Example:
+#   externalRoutes:
+#     - name: backend
+#       hostname: backend.chorus-tre.local
+#       namespace: backend
+#       serviceName: backend
+#       servicePort: 5000
+#     - name: juicefs-dashboard
+#       hostname: juicefs-dashboard.chorus-tre.local
+#       namespace: kube-system
+#       serviceName: juicefs-csi-dashboard
+#       servicePort: 8088
+externalRoutes: []
 
-  # Shell services — each entry creates a CiliumNetworkPolicy restricting ingress on the
-  # service container port to Envoy pods only (defense-in-depth).
-  # Envoy terminates the client TCP connection and opens a new one to the service pod,
-  # so the source IP at the service pod is the Envoy pod IP, not the original client IP.
-  # gatewayPort must match a tcpListeners entry in gateway-helm (Envoy remaps it to gatewayPort+10000).
-  #
-  # Example:
-  #   shellServices:
-  #     - name: gitlab-shell
-  #       namespace: gitlab
-  #       podSelector:
-  #         app: gitlab-shell
-  #       containerPort: 2222
-  #       gatewayPort: 22
-  shellServices: []
+# Open routes — accessible from both workspace pods and external browsers.
+# No SecurityPolicy restriction.
+# Each entry creates an HTTPRoute and ReferenceGrant.
+# Must be set in environment values.
+#
+# Example:
+#   openRoutes:
+#     - name: harbor
+#       hostname: harbor.chorus-tre.local
+#       namespace: harbor
+#       serviceName: harbor-core
+#       servicePort: 80
+openRoutes: []
 
-# External gateway — accessible from external browsers. No SecurityPolicy restriction.
-# Workspace pods cannot reach these (operator CNP restricts egress to internal gateway pods only).
-# The envoy-external-gateway-ingress CiliumNetworkPolicy allows all ingress on the external
-# gateway's Envoy pods (both cluster and world traffic) on port 10443.
-# Gateway name must match the Gateway metadata.name in the gateway-helm chart.
-external:
-  gateway:
-    name: chorus-external-gateway
-    namespace: envoy-gateway-system
+# Internal TCP routes — workspace pods only (SecurityPolicy allows podCIDR).
+# Each entry creates a TCPRoute forwarding gatewayPort to the service.
+# SecurityPolicy with clientCIDRs restricts access to podCIDR (same as internalRoutes).
+# gatewayPort must match a tcpListeners entry in the gateway-helm chart
+# (Envoy Gateway remaps it to gatewayPort+10000 internally, e.g. 22 → 10022).
+#
+# Example:
+#   internalTcpRoutes:
+#     - name: gitlab-shell
+#       namespace: gitlab
+#       serviceName: gitlab-shell
+#       servicePort: 22
+#       gatewayPort: 22
+internalTcpRoutes: []
 
-  # HTTPRoutes (parentRef: external gateway) and ReferenceGrants.
-  # No SecurityPolicy restriction — accessible from browsers.
-  # Supports redirectPath but not matches or gateways (dual-access is via internal.routes only).
-  # Must be set in environment values.
-  #
-  # Example:
-  #   routes:
-  #     - name: juicefs-dashboard
-  #       hostname: juicefs-dashboard.chorus-tre.local
-  #       namespace: kube-system
-  #       serviceName: juicefs-csi-driver-dashboard
-  #       servicePort: 8080
-  routes: []
+# Internal shell services — each entry creates a CiliumNetworkPolicy restricting ingress on the
+# service container port to Envoy pods only (defense-in-depth for internal TCP services).
+# Envoy terminates the client TCP connection and opens a new one to the service pod,
+# so the source IP at the service pod is the Envoy pod IP, not the original client IP.
+# gatewayPort must match a tcpListeners entry in gateway-helm (Envoy remaps it to gatewayPort+10000).
+#
+# Example:
+#   internalShellServices:
+#     - name: gitlab-shell
+#       namespace: gitlab
+#       podSelector:
+#         app: gitlab-shell
+#       containerPort: 2222
+#       gatewayPort: 22
+internalShellServices: []

--- a/charts/gateway-helm/Chart.yaml
+++ b/charts/gateway-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: The Helm chart for Envoy Gateway
 name: gateway-helm
-version: 0.0.8
+version: 0.0.9
 dependencies:
   - name: gateway-helm
     version: v1.4.1

--- a/charts/gateway-helm/templates/gateway.yaml
+++ b/charts/gateway-helm/templates/gateway.yaml
@@ -1,17 +1,15 @@
-{{- range $key, $gw := .Values.gateways }}
-{{- if $gw.listeners }}
----
+{{- if .Values.listeners }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: {{ required (print "gateways." $key ".name is required") $gw.name }}
+  name: {{ required "gateway.name is required" .Values.gateway.name }}
   namespace: envoy-gateway-system
   annotations:
-    cert-manager.io/cluster-issuer: {{ $gw.clusterIssuer | default $.Values.tls.clusterIssuer | quote }}
+    cert-manager.io/cluster-issuer: {{ .Values.clusterIssuer | quote }}
 spec:
   gatewayClassName: eg
   listeners:
-    {{- range $gw.listeners }}
+    {{- range .Values.listeners }}
     {{- /* Name: use explicit .name if set, otherwise derived from hostname (dots → dashes, * → wildcard, truncated to 63 chars).
          Hostnames that differ only by characters mapping to "-" would collide — set an explicit .name per listener to disambiguate. */}}
     - name: {{ .name | default (required "listener.hostname is required" .hostname | replace "." "-" | replace "*" "wildcard" | trunc 63) }}
@@ -29,7 +27,7 @@ spec:
           # Allow HTTPRoutes from any namespace — service charts deploy routes in their own namespaces.
           from: All
     {{- end }}
-    {{- range $gw.tcpListeners }}
+    {{- range .Values.tcpListeners }}
     - name: {{ .name | default (print "tcp-" .port) }}
       port: {{ .port }}
       protocol: TCP
@@ -37,5 +35,4 @@ spec:
         namespaces:
           from: All
     {{- end }}
-{{- end }}
 {{- end }}

--- a/charts/gateway-helm/templates/gateway.yaml
+++ b/charts/gateway-helm/templates/gateway.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.listeners }}
+{{- if or .Values.listeners .Values.tcpListeners }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:

--- a/charts/gateway-helm/values.yaml
+++ b/charts/gateway-helm/values.yaml
@@ -3,50 +3,41 @@ gateway-helm:
     priorityClassName: high-priority
 
 # The LB IP is assigned automatically by the cloud provider or load balancer controller.
-# Access restriction to workspace pods is enforced at the application layer via SecurityPolicy
+# The Gateway creates an Envoy Deployment + LoadBalancer Service with a MetalLB VIP.
+# Access restriction is enforced per-route via SecurityPolicy at the application layer
 # (not loadBalancerSourceRanges, which is incompatible with Cilium's pod IP masquerading).
-# The IP should be pointed to by an internal subdomain (e.g. internal.<domain>) to distinguish
-# it from the public ingress.
+# With externalTrafficPolicy: Local, SecurityPolicy clientCIDRs sees real source IPs
+# (pod IPs for workspace pods, external IPs for browsers).
 # To find the assigned IP after deployment:
 #   kubectl get gateway chorus-gateway -n envoy-gateway-system -o jsonpath='{.status.addresses[0].value}'
 
-tls:
-  # Default ClusterIssuer used by cert-manager to provision TLS certificates.
-  # Can be overridden per-gateway with gateways.<key>.clusterIssuer.
-  # Mixing HTTP01 and DNS01 on a single Gateway is not supported.
-  clusterIssuer: letsencrypt-prod
+# Gateway name — must match the chorus-gateway chart's gateway.name value.
+gateway:
+  name: chorus-gateway
 
-# Each key creates a separate Gateway resource with its own Envoy Deployment + LoadBalancer.
-# Each gateway gets its own MetalLB VIP automatically.
+# ClusterIssuer used by cert-manager to provision TLS certificates for HTTPS listeners.
+# All listeners share the same ClusterIssuer (cert-manager limitation:
+# mixing HTTP01 and DNS01 challenge types on the same Gateway is not supported).
+clusterIssuer: letsencrypt-prod
+
+# HTTPS listeners — one entry per hostname. cert-manager provisions one Certificate per listener.
 # Must be set in environment values.
 #
-# Listeners: one entry per hostname — cert-manager provisions one Certificate per listener.
-#   Option A — per-hostname certs (HTTP01, no DNS access required):
-#     listeners:
-#       - hostname: gitlab.chorus-tre.local
-#         secretName: gitlab-tls
-#   Option B — wildcard cert (DNS01 required, e.g. Cloudflare):
-#     listeners:
-#       - hostname: "*.chorus-tre.local"
-#         secretName: wildcard-tls
+# Option A — per-hostname certs (HTTP01, no DNS access required):
+#   listeners:
+#     - hostname: gitlab.chorus-tre.local
+#       secretName: gitlab-tls
+#     - hostname: i2b2.chorus-tre.local
+#       secretName: i2b2-tls
 #
-# TCP listeners (e.g. port 22 for GitLab SSH):
-#   tcpListeners:
-#     - port: 22
+# Option B — wildcard cert (DNS01 required, e.g. Cloudflare):
+#   listeners:
+#     - hostname: "*.chorus-tre.local"
+#       secretName: wildcard-tls
+listeners: []
+
+# TCP listeners (e.g. port 22 for GitLab SSH) — must be set in environment values.
 #
-# Example:
-#   gateways:
-#     internal:
-#       name: chorus-internal-gateway
-#       listeners:
-#         - hostname: "*.internal.chorus-tre.local"
-#           secretName: internal-tls
-#       tcpListeners:
-#         - port: 22
-#     external:
-#       name: chorus-external-gateway
-#       # clusterIssuer: letsencrypt-prod-http01  # optional per-gateway override
-#       listeners:
-#         - hostname: "*.chorus-tre.local"
-#           secretName: external-tls
-gateways: {}
+# tcpListeners:
+#   - port: 22
+tcpListeners: []


### PR DESCRIPTION
## Single gateway architecture

Replaces the dual-gateway approach with a single Envoy Gateway. Access control is enforced per-route via SecurityPolicy instead of per-gateway via CNP label filtering.

With `externalTrafficPolicy: Local`, SecurityPolicy `clientCIDRs` sees real source IPs: pod IPs for workspace pods, external IPs for browsers. This enables per-route Allow/Deny by podCIDR on a single gateway.

### gateway-helm (0.0.9)
- Revert to single Gateway resource (`chorus-gateway`)
- Flatten values: `listeners` and `tcpListeners` at top level
- Guard: Gateway renders if either `listeners` or `tcpListeners` is set
- Wildcard TLS listener for `*.int.chorus-tre.ch`

### chorus-gateway (0.0.11)
- Three SecurityPolicy groups:
  - **Internal** (allow podCIDR): gitlab, i2b2, backend IDP, SSH — workspace pods only, external clients rejected (403 for HTTP, L4 close for TCP)
  - **External** (deny podCIDR): backend full API, juicefs-dashboard — browsers only, workspace pods get 403
  - **Open** (no SP): keycloak, harbor — accessible from both
- Routes: `internalRoutes`, `externalRoutes`, `openRoutes`, `internalTcpRoutes`, `internalShellServices`
- Path-match support: backend IDP `/openid-connect/` (internal) + catch-all (external) on same hostname
- Single CNP allowing all ingress on ports 10443 + 10022 (SecurityPolicy handles access control)

### Deployment order
1. Deploy gateway-helm 0.0.9 → creates new `chorus-gateway` alongside old gateways
2. Deploy chorus-gateway 0.0.11 → routes attach to `chorus-gateway`
3. Get new LB IP: `kubectl get gateway chorus-gateway -n envoy-gateway-system -o jsonpath='{.status.addresses[0].value}'`
4. Update DNS: `gitlab.int.chorus-tre.ch`, `i2b2.int.chorus-tre.ch`, `wildfly.int.chorus-tre.ch`, `backend.int.chorus-tre.ch` → new LB IP
5. Verify services work (internal from workspace, external from browser)
6. Delete old resources:
   ```
   kubectl delete gateway chorus-internal-gateway -n envoy-gateway-system
   kubectl delete gateway chorus-external-gateway -n envoy-gateway-system
   kubectl delete ciliumnetworkpolicy envoy-internal-gateway-ingress -n envoy-gateway-system
   kubectl delete ciliumnetworkpolicy envoy-external-gateway-ingress -n envoy-gateway-system
   ```

### Source IP verification (do after deploy)
Verify Envoy sees real pod IPs from workspace pods — this is load-bearing for the security model:
```
kubectl logs -n envoy-gateway-system -l app.kubernetes.io/managed-by=envoy-gateway -c envoy --tail=5
```
Check the source IP in access logs matches the workspace pod IP (10.42.x.x), not a node IP.