### PR TITLE
feat(gateway): upgrade Envoy Gateway from v1.4.1 to v1.7.1

### DIFF
--- a/charts/gateway-crds-helm/Chart.lock
+++ b/charts/gateway-crds-helm/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: gateway-crds-helm
+  repository: oci://docker.io/envoyproxy
+  version: v1.7.1
+digest: sha256:78a5817058cd970b8afd6a436210bf4deb46e494db9304461929f59da176a0e9
+generated: "2026-04-15T12:27:20.52469+02:00"

--- a/charts/gateway-crds-helm/Chart.yaml
+++ b/charts/gateway-crds-helm/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 description: A Helm chart for Envoy Gateway CRDs
 name: gateway-crds-helm
-version: 0.0.1
+version: 0.0.2
 dependencies:
   - name: gateway-crds-helm
-    version: v1.4.1
+    version: v1.7.1
     repository: oci://docker.io/envoyproxy
 
 maintainers:

--- a/charts/gateway-helm/Chart.lock
+++ b/charts/gateway-helm/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: gateway-helm
   repository: oci://docker.io/envoyproxy
-  version: v1.4.1
-digest: sha256:dcb4768ecc4ab69fd724fad60d4580cae7e55f8aa2be16f705ea00e30d1dc88a
-generated: "2026-03-27T16:56:45.715249+01:00"
+  version: v1.7.1
+digest: sha256:4a1b1715aeefb42e3db6b0e2c2ce27d64e8b25a2c0c0985e42c9f51fbe52ec68
+generated: "2026-04-15T12:27:25.564932+02:00"

--- a/charts/gateway-helm/Chart.yaml
+++ b/charts/gateway-helm/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 description: The Helm chart for Envoy Gateway
 name: gateway-helm
-version: 0.0.9
+version: 0.0.10
 dependencies:
   - name: gateway-helm
-    version: v1.4.1
+    version: v1.7.1
     repository: oci://docker.io/envoyproxy
 
 maintainers:


### PR DESCRIPTION
## Upgrade Envoy Gateway v1.4.1 → v1.7.1

v1.4 reached EOL on 2025-11-13. Upgrading to v1.7.1 (latest stable, 2026-03-12).

### Key feature unlocked
- **SecurityPolicy on TCPRoute** (added in v1.6.0) — enables clientCIDR-based access control on TCP services (e.g. GitLab SSH). Required for the single-gateway architecture where SSH must be restricted to workspace pods via SecurityPolicy.

### Charts bumped
- gateway-crds-helm: 0.0.1 → 0.0.2 (CRDs from v1.7.1)
- gateway-helm: 0.0.9 → 0.0.10 (upstream chart v1.7.1)

### Deploy order
CRDs (gateway-crds-helm) must be deployed before infrastructure (gateway-helm). ArgoCD stepName handles this automatically.

### Breaking changes on the upgrade path
None that affect our setup. The documented breaking changes between v1.4 and v1.7 affect EnvoyPatchPolicy naming (we don't use it), ALPNProtocols defaults (we don't configure it), and MirrorPolicy naming (we don't use it).