### PR TITLE
feat(chorus-gateway): add ExtAuth support, migrate all nginx services (0.0.12)

### DIFF
--- a/charts/chorus-gateway/Chart.yaml
+++ b/charts/chorus-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: chorus-gateway
 description: Envoy Gateway HTTPRoutes and SecurityPolicies for CHORUS services
-version: 0.0.11
+version: 0.0.12
 maintainers:
   - name: iDmple
     email: nathalie.casati@chuv.ch

--- a/charts/chorus-gateway/templates/clienttrafficpolicy.yaml
+++ b/charts/chorus-gateway/templates/clienttrafficpolicy.yaml
@@ -1,0 +1,24 @@
+{{- /*
+  ClientTrafficPolicy — path handling for the gateway.
+
+  escapedSlashesAction: UnescapeAndForward
+    Decodes %2F to / and forwards to the backend without a redirect.
+    Envoy's default is UnescapeAndRedirect, which returns a 307 to the decoded
+    path. That redirect has no CORS headers, so browser XHR/fetch fails CORS
+    on paths containing %2F (observed with backend file-archive endpoints where
+    the frontend URL-encodes a trailing slash).
+*/}}
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: gateway-path-handling
+  namespace: {{ .Values.gateway.namespace }}
+  labels:
+    {{- include "chorus-gateway.labels" . | nindent 4 }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ .Values.gateway.name }}
+  path:
+    escapedSlashesAction: UnescapeAndForward

--- a/charts/chorus-gateway/templates/httproutes.yaml
+++ b/charts/chorus-gateway/templates/httproutes.yaml
@@ -91,6 +91,38 @@ spec:
 {{- end }}
 
 {{- /*
+  ExtAuth callback routes — for external routes with extAuth, create an open HTTPRoute
+  on /oauth2 path that routes to the oauth2-proxy service for callback handling.
+  No SecurityPolicy — must be accessible for the OAuth2 flow to complete.
+*/}}
+{{- range .Values.externalRoutes }}
+{{- if .extAuth }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .name }}-oauth2-httproute
+  namespace: {{ $.Values.gateway.namespace }}
+  labels:
+    {{- include "chorus-gateway.labels" $ | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ $.Values.gateway.name }}
+  hostnames:
+    - {{ .hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /oauth2
+      backendRefs:
+        - name: {{ .extAuth.serviceName }}
+          namespace: {{ .extAuth.namespace }}
+          port: {{ .extAuth.servicePort }}
+{{- end }}
+{{- end }}
+
+{{- /*
   Open routes — accessible from both workspace pods and external browsers.
   No SecurityPolicy restriction.
 */}}

--- a/charts/chorus-gateway/templates/httproutes.yaml
+++ b/charts/chorus-gateway/templates/httproutes.yaml
@@ -91,9 +91,11 @@ spec:
 {{- end }}
 
 {{- /*
-  ExtAuth callback routes — for external routes with extAuth, create an open HTTPRoute
+  ExtAuth callback routes — for external routes with extAuth, create an HTTPRoute
   on /oauth2 path that routes to the oauth2-proxy service for callback handling.
-  No SecurityPolicy — must be accessible for the OAuth2 flow to complete.
+  Targeted by external-securitypolicy (deny podCIDR) so workspace pods can't hit
+  the callback, while external browsers complete the OAuth2 flow normally.
+  No ExtAuth SecurityPolicy — the callback itself must not require auth.
 */}}
 {{- range .Values.externalRoutes }}
 {{- if .extAuth }}

--- a/charts/chorus-gateway/templates/referencegrants.yaml
+++ b/charts/chorus-gateway/templates/referencegrants.yaml
@@ -1,13 +1,35 @@
-{{- $seenNamespaces := dict }}
-{{- range concat .Values.internalRoutes .Values.externalRoutes .Values.openRoutes }}
-{{- if not (hasKey $seenNamespaces .namespace) }}
-{{- $_ := set $seenNamespaces .namespace true }}
+{{- /*
+  Collect namespaces that host an extAuth backend Service.
+  SecurityPolicy.extAuth.http.backendRefs is a cross-namespace reference from
+  SecurityPolicy (in gateway.namespace) to a Service (in extAuth.namespace),
+  so those grants must additionally allow SecurityPolicy as a `from`.
+*/}}
+{{- $extAuthNamespaces := dict }}
+{{- range .Values.externalRoutes }}
+{{- if .extAuth }}
+{{- $_ := set $extAuthNamespaces .extAuth.namespace true }}
+{{- end }}
+{{- end }}
+
+{{- /*
+  Collect every namespace that needs a ReferenceGrant — any namespace that
+  hosts a backend Service referenced from the gateway namespace.
+*/}}
+{{- $grantNamespaces := dict }}
+{{- range concat .Values.internalRoutes .Values.externalRoutes .Values.openRoutes .Values.internalTcpRoutes }}
+{{- $_ := set $grantNamespaces .namespace true }}
+{{- end }}
+{{- range $ns, $_ := $extAuthNamespaces }}
+{{- $_ := set $grantNamespaces $ns true }}
+{{- end }}
+
+{{- range $ns, $_ := $grantNamespaces }}
 ---
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant
 metadata:
-  name: {{ .namespace }}-referencegrant
-  namespace: {{ .namespace }}
+  name: {{ $ns }}-referencegrant
+  namespace: {{ $ns }}
   labels:
     {{- include "chorus-gateway.labels" $ | nindent 4 }}
 spec:
@@ -18,8 +40,12 @@ spec:
     - group: gateway.networking.k8s.io
       kind: TCPRoute
       namespace: {{ $.Values.gateway.namespace }}
+    {{- if hasKey $extAuthNamespaces $ns }}
+    - group: gateway.envoyproxy.io
+      kind: SecurityPolicy
+      namespace: {{ $.Values.gateway.namespace }}
+    {{- end }}
   to:
     - group: ""
       kind: Service
-{{- end }}
 {{- end }}

--- a/charts/chorus-gateway/templates/securitypolicy.yaml
+++ b/charts/chorus-gateway/templates/securitypolicy.yaml
@@ -37,6 +37,7 @@ spec:
 {{- /*
   External SecurityPolicy — denies podCIDR (workspace pods get 403).
   External browsers are allowed (defaultAction: Allow).
+  Routes with extAuth are excluded — they get their own ExtAuth SecurityPolicy below.
 */}}
 {{- if .Values.externalRoutes }}
 ---
@@ -50,9 +51,17 @@ metadata:
 spec:
   targetRefs:
     {{- range .Values.externalRoutes }}
+    {{- if not .extAuth }}
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       name: {{ .name }}-external-httproute
+    {{- end }}
+    {{- /* OAuth2 callback routes for extAuth routes — deny podCIDR too */}}
+    {{- if .extAuth }}
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ .name }}-oauth2-httproute
+    {{- end }}
     {{- end }}
   authorization:
     defaultAction: Allow
@@ -62,6 +71,58 @@ spec:
         principal:
           clientCIDRs:
             - {{ required "podCIDR must be set to match the cluster's pod CIDR" .Values.podCIDR | quote }}
+{{- end }}
+
+{{- /*
+  ExtAuth SecurityPolicies — one per external route that has extAuth configured.
+  Uses Envoy external authorization to forward auth checks to an oauth2-proxy service.
+  Also denies podCIDR (workspace pods) via authorization rules.
+*/}}
+{{- range .Values.externalRoutes }}
+{{- if .extAuth }}
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ .name }}-extauth-securitypolicy
+  namespace: {{ $.Values.gateway.namespace }}
+  labels:
+    {{- include "chorus-gateway.labels" $ | nindent 4 }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ .name }}-external-httproute
+  authorization:
+    defaultAction: Allow
+    rules:
+      - name: deny-workspace-pods
+        action: Deny
+        principal:
+          clientCIDRs:
+            - {{ required "podCIDR must be set" $.Values.podCIDR | quote }}
+  extAuth:
+    failOpen: false
+    headersToExtAuth:
+      - Cookie
+      - Authorization
+      - X-Forwarded-Proto
+      - X-Forwarded-Host
+      - X-Forwarded-Uri
+    http:
+      backendRefs:
+        - group: ""
+          kind: Service
+          name: {{ required "extAuth.serviceName is required" .extAuth.serviceName }}
+          namespace: {{ required "extAuth.namespace is required" .extAuth.namespace }}
+          port: {{ required "extAuth.servicePort is required" .extAuth.servicePort }}
+      path: {{ .extAuth.path | default "/oauth2/auth" }}
+      headersToBackend:
+        - X-Auth-Request-User
+        - X-Auth-Request-Email
+        - X-Auth-Request-Groups
+        - X-Auth-Request-Access-Token
+{{- end }}
 {{- end }}
 
 {{- /* Open routes have no SecurityPolicy — accessible from everyone. */}}

--- a/charts/chorus-gateway/templates/securitypolicy.yaml
+++ b/charts/chorus-gateway/templates/securitypolicy.yaml
@@ -22,7 +22,7 @@ spec:
     {{- range .Values.internalTcpRoutes }}
     - group: gateway.networking.k8s.io
       kind: TCPRoute
-      name: {{ .name }}
+      name: {{ .name }}-internal-tcproute
     {{- end }}
   authorization:
     defaultAction: Deny

--- a/charts/chorus-gateway/templates/securitypolicy.yaml
+++ b/charts/chorus-gateway/templates/securitypolicy.yaml
@@ -100,15 +100,17 @@ spec:
         action: Deny
         principal:
           clientCIDRs:
-            - {{ required "podCIDR must be set" $.Values.podCIDR | quote }}
+            - {{ required "podCIDR must be set to match the cluster's pod CIDR" $.Values.podCIDR | quote }}
   extAuth:
     failOpen: false
     headersToExtAuth:
       - Cookie
       - Authorization
+      - Accept
       - X-Forwarded-Proto
       - X-Forwarded-Host
       - X-Forwarded-Uri
+      - X-Auth-Request-Redirect
     http:
       backendRefs:
         - group: ""

--- a/charts/chorus-gateway/templates/securitypolicy.yaml
+++ b/charts/chorus-gateway/templates/securitypolicy.yaml
@@ -56,7 +56,7 @@ spec:
       kind: HTTPRoute
       name: {{ .name }}-external-httproute
     {{- end }}
-    {{- /* OAuth2 callback routes for extAuth routes — deny podCIDR too */}}
+    {{- /* OAuth2 callback routes for extAuth routes — deny podCIDR */}}
     {{- if .extAuth }}
     - group: gateway.networking.k8s.io
       kind: HTTPRoute

--- a/charts/chorus-gateway/templates/tcproutes.yaml
+++ b/charts/chorus-gateway/templates/tcproutes.yaml
@@ -3,7 +3,7 @@
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TCPRoute
 metadata:
-  name: {{ required "tcpRoute.name is required" .name }}
+  name: {{ required "tcpRoute.name is required" .name }}-internal-tcproute
   namespace: {{ $.Values.gateway.namespace }}
   labels:
     {{- include "chorus-gateway.labels" $ | nindent 4 }}

--- a/charts/chorus-gateway/values.yaml
+++ b/charts/chorus-gateway/values.yaml
@@ -7,7 +7,8 @@
 # Derive the cluster supernet by keeping the first two octets and using /16 (e.g. 192.168.0.0/16).
 podCIDR: ""
 
-# Gateway reference — must match the Gateway metadata.name in the gateway-helm chart.
+# Gateway reference. `name` must match `gateway.name` in the gateway-helm chart
+# (routes attach to that Gateway by name). Rename in both charts.
 gateway:
   name: chorus-gateway
   namespace: envoy-gateway-system
@@ -57,11 +58,9 @@ internalRoutes: []
 #       namespace: backend
 #       serviceName: backend
 #       servicePort: 5000
-#     - name: juicefs-dashboard
-#       hostname: juicefs-dashboard.chorus-tre.local
-#       namespace: kube-system
-#       serviceName: juicefs-csi-dashboard
-#       servicePort: 8088
+#     # Routes for services without built-in auth must use extAuth (see below) —
+#     # exposing them with just SecurityPolicy denies workspace pods but leaves
+#     # them open to any external browser.
 #     # Routes with extAuth get an ExtAuth SecurityPolicy + a /oauth2 callback route.
 #     # The oauth2-proxy handles authentication via Keycloak OIDC.
 #     - name: prometheus

--- a/charts/chorus-gateway/values.yaml
+++ b/charts/chorus-gateway/values.yaml
@@ -62,6 +62,17 @@ internalRoutes: []
 #       namespace: kube-system
 #       serviceName: juicefs-csi-dashboard
 #       servicePort: 8088
+#     # Routes with extAuth get an ExtAuth SecurityPolicy + a /oauth2 callback route.
+#     # The oauth2-proxy handles authentication via Keycloak OIDC.
+#     - name: prometheus
+#       hostname: prometheus.chorus-tre.local
+#       namespace: prometheus
+#       serviceName: prometheus
+#       servicePort: 9090
+#       extAuth:
+#         serviceName: prometheus-oauth2-proxy
+#         namespace: prometheus
+#         servicePort: 80
 externalRoutes: []
 
 # Open routes — accessible from both workspace pods and external browsers.

--- a/charts/gateway-helm/values.yaml
+++ b/charts/gateway-helm/values.yaml
@@ -11,7 +11,8 @@ gateway-helm:
 # To find the assigned IP after deployment:
 #   kubectl get gateway chorus-gateway -n envoy-gateway-system -o jsonpath='{.status.addresses[0].value}'
 
-# Gateway name — must match the chorus-gateway chart's gateway.name value.
+# Gateway name. Must match `gateway.name` in the chorus-gateway chart
+# (HTTPRoutes/TCPRoutes/SecurityPolicies attach by name). Rename in both charts.
 gateway:
   name: chorus-gateway
 


### PR DESCRIPTION
## Migrate all nginx services to Envoy Gateway

Adds all remaining nginx services as external routes with per-route SecurityPolicy. After deploying, nginx can be removed from chorus-int.

### New external routes
- Web UI (int.chorus-tre.ch)
- Keycloak (auth.int.chorus-tre.ch) — uses HTTP port 80, no BackendTLSPolicy needed
- Grafana (grafana.int.chorus-tre.ch)
- Harbor (harbor.int.chorus-tre.ch)
- Prometheus (prometheus.int.chorus-tre.ch) — with ExtAuth → oauth2-proxy
- Alertmanager (alertmanager.int.chorus-tre.ch) — with ExtAuth → oauth2-proxy

### ExtAuth support
Routes with `extAuth` field get:
- Their own ExtAuth SecurityPolicy (deny podCIDR + OAuth2 authentication via oauth2-proxy)
- A companion `/oauth2` callback HTTPRoute (deny podCIDR via external SecurityPolicy)

### Matomo
Left on its own LoadBalancer (148.187.90.116). Not migrated — workspace pods can't reach it.

### DNS
After deploying, set wildcard `*.int.chorus-tre.ch` → 148.187.90.118 and disable all nginx ingresses.