### PR TITLE
feat(chorus-gateway,matomo,juicefs,didata): 403 page + disable nginx ingress defaults

### DIFF
--- a/charts/chorus-gateway/Chart.yaml
+++ b/charts/chorus-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: chorus-gateway
 description: Envoy Gateway HTTPRoutes and SecurityPolicies for CHORUS services
-version: 0.0.13
+version: 0.0.14
 maintainers:
   - name: iDmple
     email: nathalie.casati@chuv.ch

--- a/charts/chorus-gateway/templates/backendtrafficpolicy.yaml
+++ b/charts/chorus-gateway/templates/backendtrafficpolicy.yaml
@@ -1,0 +1,32 @@
+{{- /*
+  BackendTrafficPolicy per internal HTTPRoute — replaces Envoy's default
+  "RBAC: access denied" body with a friendlier HTML page whenever the
+  internal SecurityPolicy rejects a request (i.e. non-podCIDR source).
+*/}}
+{{- if and .Values.internalAccessDeniedHTML .Values.internalRoutes }}
+{{- range .Values.internalRoutes }}
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: {{ .name }}-internal-access-denied
+  namespace: {{ $.Values.gateway.namespace }}
+  labels:
+    {{- include "chorus-gateway.labels" $ | nindent 4 }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ .name }}-internal-httproute
+  responseOverride:
+    - match:
+        statusCodes:
+          - type: Value
+            value: 403
+      response:
+        contentType: text/html
+        body:
+          type: Inline
+          inline: {{ $.Values.internalAccessDeniedHTML | toJson }}
+{{- end }}
+{{- end }}

--- a/charts/chorus-gateway/values.yaml
+++ b/charts/chorus-gateway/values.yaml
@@ -42,6 +42,29 @@ gateway:
 #         - pathPrefix: /openid-connect
 internalRoutes: []
 
+# HTML body returned when an internal route denies an external client (SecurityPolicy 403).
+# Replaces the default "RBAC: access denied" text with a user-friendly page via a
+# BackendTrafficPolicy + responseOverride on each internal HTTPRoute.
+# Set to "" to disable the override and keep Envoy's default response body.
+internalAccessDeniedHTML: |-
+  <!doctype html>
+  <html>
+    <head>
+      <meta charset="utf-8">
+      <title>Access denied</title>
+      <style>
+        body { font-family: system-ui, sans-serif; margin: 4rem auto; max-width: 40rem; color: #333; }
+        h1 { color: #222; }
+        p { line-height: 1.5; }
+      </style>
+    </head>
+    <body>
+      <h1>Access denied</h1>
+      <p>This service is only reachable from inside a CHORUS workspace.</p>
+      <p>Please open it from within your workspace.</p>
+    </body>
+  </html>
+
 # External routes — accessible from external browsers only (SecurityPolicy denies podCIDR).
 # Workspace pods get 403.
 # Each entry creates an HTTPRoute and ReferenceGrant.

--- a/charts/didata/Chart.yaml
+++ b/charts/didata/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.18
+version: 0.0.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/didata/values.yaml
+++ b/charts/didata/values.yaml
@@ -123,19 +123,7 @@ networkPolicy:
         - {}
 
 ingress:
-  enabled: true
-  className: "nginx"
-  annotations:
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
-  hosts:
-    - host: didata.chorus-tre.local
-      paths:
-        - path: /
-          pathType: Prefix
-  tls:
-    - secretName: didata-tls
-      hosts:
-        - didata.chorus-tre.local
+  enabled: false
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/juicefs-csi-driver/Chart.yaml
+++ b/charts/juicefs-csi-driver/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: juicefs-csi-driver
 description: A Helm chart for JuiceFS CSI Driver.
-version: 0.0.15
+version: 0.0.16
 dependencies:
   - name: juicefs-csi-driver
     version: 0.31.1

--- a/charts/juicefs-csi-driver/values.yaml
+++ b/charts/juicefs-csi-driver/values.yaml
@@ -57,17 +57,5 @@ juicefs-csi-driver:
       enabled: true
       existingSecret: "juicefs-dashboard-secret"
     ingress:
-      enabled: true
-      className: "nginx"
-      annotations:
-        cert-manager.io/cluster-issuer: "letsencrypt-prod"
-      hosts:
-      - host: "juicefs-dashboard.chorus-tre.local"
-        paths:
-        - path: /
-          pathType: ImplementationSpecific
-      tls:
-        - secretName: juicefs-dashboard-tls
-          hosts:
-            - juicefs-dashboard.chorus-tre.local
+      enabled: false
     priorityClassName: "low-priority"

--- a/charts/matomo/Chart.yaml
+++ b/charts/matomo/Chart.yaml
@@ -5,7 +5,7 @@ maintainers:
   - name: iDmple
     email: nathalie.casati@chuv.ch
 
-version: 0.0.11
+version: 0.0.12
 dependencies:
   - name: matomo
     version: 9.3.13

--- a/charts/matomo/values.yaml
+++ b/charts/matomo/values.yaml
@@ -12,14 +12,9 @@ matomo:
   updateStrategy:
     type: Recreate
   ingress:
-    enabled: true
-    pathType: Prefix
-    ingressClassName: "nginx"
-    hostname: "matomo.chorus-tre.local"
-    annotations:
-      cert-manager.io/cluster-issuer: "letsencrypt-prod"
-    tls: true
-    selfSigned: false
+    enabled: false
+  service:
+    type: ClusterIP
   mariadb:
     enabled: false
   externalDatabase:


### PR DESCRIPTION
## Charts

### chorus-gateway 0.0.14
- New \`internalAccessDeniedHTML\` value + BackendTrafficPolicy per internal HTTPRoute that replaces Envoy's bare \`RBAC: access denied\` with a small HTML page telling users to open the service from within their workspace.
- Set to \`""\` to keep Envoy's default body.

### matomo 0.0.12
- Disable bundled nginx ingress, switch Service to ClusterIP. TLS and routing now handled by the chorus-gateway chart.

### juicefs-csi-driver 0.0.16
- Disable dashboard nginx ingress by default (already overridden in env). Same pattern as other migrated charts.

### didata 0.0.19
- Disable nginx ingress by default.

Paired env change adds a matomo route to \`externalRoutes\` in chorus-gateway and bumps all four chart pins.