### PR TITLE
feat(chorus-gateway): support matches on externalRoutes (0.0.15)

### DIFF
--- a/charts/chorus-gateway/Chart.yaml
+++ b/charts/chorus-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: chorus-gateway
 description: Envoy Gateway HTTPRoutes and SecurityPolicies for CHORUS services
-version: 0.0.16
+version: 0.0.15
 maintainers:
   - name: iDmple
     email: nathalie.casati@chuv.ch

--- a/charts/chorus-gateway/Chart.yaml
+++ b/charts/chorus-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: chorus-gateway
 description: Envoy Gateway HTTPRoutes and SecurityPolicies for CHORUS services
-version: 0.0.15
+version: 0.0.16
 maintainers:
   - name: iDmple
     email: nathalie.casati@chuv.ch

--- a/charts/chorus-gateway/Chart.yaml
+++ b/charts/chorus-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: chorus-gateway
 description: Envoy Gateway HTTPRoutes and SecurityPolicies for CHORUS services
-version: 0.0.14
+version: 0.0.15
 maintainers:
   - name: iDmple
     email: nathalie.casati@chuv.ch

--- a/charts/chorus-gateway/templates/_helpers.tpl
+++ b/charts/chorus-gateway/templates/_helpers.tpl
@@ -14,3 +14,74 @@ app.kubernetes.io/name: {{ .Chart.Name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
+
+{{/*
+Single backendRef list for an HTTPRoute, derived from a route entry.
+Argument: a route map with serviceName, namespace, servicePort.
+*/}}
+{{- define "chorus-gateway.backendRef" -}}
+- name: {{ required "route.serviceName is required" .serviceName }}
+  namespace: {{ required "route.namespace is required" .namespace }}
+  port: {{ required "route.servicePort is required" .servicePort }}
+{{- end }}
+
+{{/*
+Redirect-on-exact-"/" rule used when a route defines redirectPath.
+Gateway API evaluates matches-bearing rules before match-less ones, so this
+takes precedence over the catchall backendRefs that follows in the template.
+Argument: a route map with redirectPath.
+*/}}
+{{- define "chorus-gateway.redirectOnRoot" -}}
+- matches:
+    - path:
+        type: Exact
+        value: /
+  filters:
+    - type: RequestRedirect
+      requestRedirect:
+        path:
+          type: ReplaceFullPath
+          replaceFullPath: {{ .redirectPath | quote }}
+{{- end }}
+
+{{/*
+SecurityPolicy authorization rule scoped to the cluster pod CIDR.
+Argument: dict with keys `name` (rule name), `action` ("Allow" or "Deny"),
+`podCIDR` (the cluster pod CIDR as a string).
+*/}}
+{{- define "chorus-gateway.podCIDRRule" -}}
+- name: {{ .name }}
+  action: {{ .action }}
+  principal:
+    clientCIDRs:
+      - {{ required "podCIDR must be set to match the cluster's pod CIDR" .podCIDR | quote }}
+{{- end }}
+
+{{/*
+Route-name helpers — centralize the naming convention so renaming a suffix
+is a one-line change in _helpers.tpl rather than chasing strings across
+multiple templates. All take a route map and return "<route.name>-<suffix>".
+*/}}
+{{- define "chorus-gateway.internalHTTPRouteName" -}}
+{{- printf "%s-internal-httproute" (required "route.name is required" .name) -}}
+{{- end }}
+
+{{- define "chorus-gateway.externalHTTPRouteName" -}}
+{{- printf "%s-external-httproute" (required "route.name is required" .name) -}}
+{{- end }}
+
+{{- define "chorus-gateway.oauth2HTTPRouteName" -}}
+{{- printf "%s-oauth2-httproute" (required "route.name is required" .name) -}}
+{{- end }}
+
+{{- define "chorus-gateway.openHTTPRouteName" -}}
+{{- printf "%s-open-httproute" (required "route.name is required" .name) -}}
+{{- end }}
+
+{{- define "chorus-gateway.internalTCPRouteName" -}}
+{{- printf "%s-internal-tcproute" (required "route.name is required" .name) -}}
+{{- end }}
+
+{{- define "chorus-gateway.extAuthSecurityPolicyName" -}}
+{{- printf "%s-extauth-securitypolicy" (required "route.name is required" .name) -}}
+{{- end }}

--- a/charts/chorus-gateway/templates/_helpers.tpl
+++ b/charts/chorus-gateway/templates/_helpers.tpl
@@ -20,9 +20,9 @@ Single backendRef list for an HTTPRoute, derived from a route entry.
 Argument: a route map with serviceName, namespace, servicePort.
 */}}
 {{- define "chorus-gateway.backendRef" -}}
-- name: {{ required "route.serviceName is required" .serviceName }}
-  namespace: {{ required "route.namespace is required" .namespace }}
-  port: {{ required "route.servicePort is required" .servicePort }}
+- name: {{ required "serviceName is required" .serviceName }}
+  namespace: {{ required "namespace is required" .namespace }}
+  port: {{ required "servicePort is required" .servicePort }}
 {{- end }}
 
 {{/*
@@ -63,25 +63,25 @@ is a one-line change in _helpers.tpl rather than chasing strings across
 multiple templates. All take a route map and return "<route.name>-<suffix>".
 */}}
 {{- define "chorus-gateway.internalHTTPRouteName" -}}
-{{- printf "%s-internal-httproute" (required "route.name is required" .name) -}}
+{{- printf "%s-internal-httproute" (required "name is required" .name) -}}
 {{- end }}
 
 {{- define "chorus-gateway.externalHTTPRouteName" -}}
-{{- printf "%s-external-httproute" (required "route.name is required" .name) -}}
+{{- printf "%s-external-httproute" (required "name is required" .name) -}}
 {{- end }}
 
 {{- define "chorus-gateway.oauth2HTTPRouteName" -}}
-{{- printf "%s-oauth2-httproute" (required "route.name is required" .name) -}}
+{{- printf "%s-oauth2-httproute" (required "name is required" .name) -}}
 {{- end }}
 
 {{- define "chorus-gateway.openHTTPRouteName" -}}
-{{- printf "%s-open-httproute" (required "route.name is required" .name) -}}
+{{- printf "%s-open-httproute" (required "name is required" .name) -}}
 {{- end }}
 
 {{- define "chorus-gateway.internalTCPRouteName" -}}
-{{- printf "%s-internal-tcproute" (required "route.name is required" .name) -}}
+{{- printf "%s-internal-tcproute" (required "name is required" .name) -}}
 {{- end }}
 
 {{- define "chorus-gateway.extAuthSecurityPolicyName" -}}
-{{- printf "%s-extauth-securitypolicy" (required "route.name is required" .name) -}}
+{{- printf "%s-extauth-securitypolicy" (required "name is required" .name) -}}
 {{- end }}

--- a/charts/chorus-gateway/templates/backendtrafficpolicy.yaml
+++ b/charts/chorus-gateway/templates/backendtrafficpolicy.yaml
@@ -17,7 +17,7 @@ spec:
   targetRefs:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
-      name: {{ .name }}-internal-httproute
+      name: {{ include "chorus-gateway.internalHTTPRouteName" . }}
   responseOverride:
     - match:
         statusCodes:

--- a/charts/chorus-gateway/templates/ciliumnetworkpolicy.yaml
+++ b/charts/chorus-gateway/templates/ciliumnetworkpolicy.yaml
@@ -39,7 +39,7 @@ apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
   name: {{ .name }}-service-ingress
-  namespace: {{ required "shellService.namespace is required" .namespace }}
+  namespace: {{ required "namespace is required" .namespace }}
   labels:
     {{- include "chorus-gateway.labels" $ | nindent 4 }}
 spec:

--- a/charts/chorus-gateway/templates/httproutes.yaml
+++ b/charts/chorus-gateway/templates/httproutes.yaml
@@ -16,7 +16,7 @@ spec:
   parentRefs:
     - name: {{ $.Values.gateway.name }}
   hostnames:
-    - {{ required "route.hostname is required" .hostname | quote }}
+    - {{ required "hostname is required" .hostname | quote }}
   rules:
     {{- if .redirectPath }}
     {{- include "chorus-gateway.redirectOnRoot" . | nindent 4 }}
@@ -26,7 +26,7 @@ spec:
     - matches:
         - path:
             type: PathPrefix
-            value: {{ required "match.pathPrefix is required" .pathPrefix | quote }}
+            value: {{ required "pathPrefix is required" .pathPrefix | quote }}
       backendRefs:
         {{- include "chorus-gateway.backendRef" $route | nindent 8 }}
     {{- end }}
@@ -56,7 +56,7 @@ spec:
   parentRefs:
     - name: {{ $.Values.gateway.name }}
   hostnames:
-    - {{ required "route.hostname is required" .hostname | quote }}
+    - {{ required "hostname is required" .hostname | quote }}
   rules:
     {{- if .redirectPath }}
     {{- include "chorus-gateway.redirectOnRoot" . | nindent 4 }}
@@ -66,7 +66,7 @@ spec:
     - matches:
         - path:
             type: PathPrefix
-            value: {{ required "match.pathPrefix is required" .pathPrefix | quote }}
+            value: {{ required "pathPrefix is required" .pathPrefix | quote }}
       backendRefs:
         {{- include "chorus-gateway.backendRef" $route | nindent 8 }}
     {{- end }}
@@ -128,7 +128,7 @@ spec:
   parentRefs:
     - name: {{ $.Values.gateway.name }}
   hostnames:
-    - {{ required "route.hostname is required" .hostname | quote }}
+    - {{ required "hostname is required" .hostname | quote }}
   rules:
     {{- if .redirectPath }}
     {{- include "chorus-gateway.redirectOnRoot" . | nindent 4 }}
@@ -138,7 +138,7 @@ spec:
     - matches:
         - path:
             type: PathPrefix
-            value: {{ required "match.pathPrefix is required" .pathPrefix | quote }}
+            value: {{ required "pathPrefix is required" .pathPrefix | quote }}
       backendRefs:
         {{- include "chorus-gateway.backendRef" $route | nindent 8 }}
     {{- end }}

--- a/charts/chorus-gateway/templates/httproutes.yaml
+++ b/charts/chorus-gateway/templates/httproutes.yaml
@@ -54,8 +54,11 @@ spec:
 {{- /*
   External routes — browsers only (SecurityPolicy denies podCIDR).
   Workspace pods get 403.
+  Optional: matches (path-restricted, e.g. restrict only /admin to browsers
+  while leaving the rest of the hostname on an openRoute).
 */}}
 {{- range .Values.externalRoutes }}
+{{- $route := . }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -84,10 +87,23 @@ spec:
               type: ReplaceFullPath
               replaceFullPath: {{ .redirectPath | quote }}
     {{- end }}
+    {{- if .matches }}
+    {{- range .matches }}
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ required "match.pathPrefix is required" .pathPrefix | quote }}
+      backendRefs:
+        - name: {{ required "route.serviceName is required" $route.serviceName }}
+          namespace: {{ required "route.namespace is required" $route.namespace }}
+          port: {{ required "route.servicePort is required" $route.servicePort }}
+    {{- end }}
+    {{- else }}
     - backendRefs:
         - name: {{ required "route.serviceName is required" .serviceName }}
           namespace: {{ required "route.namespace is required" .namespace }}
           port: {{ required "route.servicePort is required" .servicePort }}
+    {{- end }}
 {{- end }}
 
 {{- /*

--- a/charts/chorus-gateway/templates/httproutes.yaml
+++ b/charts/chorus-gateway/templates/httproutes.yaml
@@ -8,7 +8,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: {{ required "route.name is required" .name }}-internal-httproute
+  name: {{ include "chorus-gateway.internalHTTPRouteName" . }}
   namespace: {{ $.Values.gateway.namespace }}
   labels:
     {{- include "chorus-gateway.labels" $ | nindent 4 }}
@@ -19,18 +19,7 @@ spec:
     - {{ required "route.hostname is required" .hostname | quote }}
   rules:
     {{- if .redirectPath }}
-    {{- /* Redirect on exact "/" — Gateway API evaluates matches-bearing rules before
-         match-less ones, so this takes precedence over the catchall backendRefs below. */}}
-    - matches:
-        - path:
-            type: Exact
-            value: /
-      filters:
-        - type: RequestRedirect
-          requestRedirect:
-            path:
-              type: ReplaceFullPath
-              replaceFullPath: {{ .redirectPath | quote }}
+    {{- include "chorus-gateway.redirectOnRoot" . | nindent 4 }}
     {{- end }}
     {{- if .matches }}
     {{- range .matches }}
@@ -39,15 +28,11 @@ spec:
             type: PathPrefix
             value: {{ required "match.pathPrefix is required" .pathPrefix | quote }}
       backendRefs:
-        - name: {{ required "route.serviceName is required" $route.serviceName }}
-          namespace: {{ required "route.namespace is required" $route.namespace }}
-          port: {{ required "route.servicePort is required" $route.servicePort }}
+        {{- include "chorus-gateway.backendRef" $route | nindent 8 }}
     {{- end }}
     {{- else }}
     - backendRefs:
-        - name: {{ required "route.serviceName is required" .serviceName }}
-          namespace: {{ required "route.namespace is required" .namespace }}
-          port: {{ required "route.servicePort is required" .servicePort }}
+        {{- include "chorus-gateway.backendRef" . | nindent 8 }}
     {{- end }}
 {{- end }}
 
@@ -63,7 +48,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: {{ required "route.name is required" .name }}-external-httproute
+  name: {{ include "chorus-gateway.externalHTTPRouteName" . }}
   namespace: {{ $.Values.gateway.namespace }}
   labels:
     {{- include "chorus-gateway.labels" $ | nindent 4 }}
@@ -74,18 +59,7 @@ spec:
     - {{ required "route.hostname is required" .hostname | quote }}
   rules:
     {{- if .redirectPath }}
-    {{- /* Redirect on exact "/" — Gateway API evaluates matches-bearing rules before
-         match-less ones, so this takes precedence over the catchall backendRefs below. */}}
-    - matches:
-        - path:
-            type: Exact
-            value: /
-      filters:
-        - type: RequestRedirect
-          requestRedirect:
-            path:
-              type: ReplaceFullPath
-              replaceFullPath: {{ .redirectPath | quote }}
+    {{- include "chorus-gateway.redirectOnRoot" . | nindent 4 }}
     {{- end }}
     {{- if .matches }}
     {{- range .matches }}
@@ -94,15 +68,11 @@ spec:
             type: PathPrefix
             value: {{ required "match.pathPrefix is required" .pathPrefix | quote }}
       backendRefs:
-        - name: {{ required "route.serviceName is required" $route.serviceName }}
-          namespace: {{ required "route.namespace is required" $route.namespace }}
-          port: {{ required "route.servicePort is required" $route.servicePort }}
+        {{- include "chorus-gateway.backendRef" $route | nindent 8 }}
     {{- end }}
     {{- else }}
     - backendRefs:
-        - name: {{ required "route.serviceName is required" .serviceName }}
-          namespace: {{ required "route.namespace is required" .namespace }}
-          port: {{ required "route.servicePort is required" .servicePort }}
+        {{- include "chorus-gateway.backendRef" . | nindent 8 }}
     {{- end }}
 {{- end }}
 
@@ -119,7 +89,7 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: {{ .name }}-oauth2-httproute
+  name: {{ include "chorus-gateway.oauth2HTTPRouteName" . }}
   namespace: {{ $.Values.gateway.namespace }}
   labels:
     {{- include "chorus-gateway.labels" $ | nindent 4 }}
@@ -134,22 +104,23 @@ spec:
             type: PathPrefix
             value: /oauth2
       backendRefs:
-        - name: {{ .extAuth.serviceName }}
-          namespace: {{ .extAuth.namespace }}
-          port: {{ .extAuth.servicePort }}
+        {{- include "chorus-gateway.backendRef" .extAuth | nindent 8 }}
 {{- end }}
 {{- end }}
 
 {{- /*
   Open routes — accessible from both workspace pods and external browsers.
   No SecurityPolicy restriction.
+  Optional: matches (path-restricted, e.g. only /v2 and /service/token open
+  while the rest of the hostname is an externalRoute catchall).
 */}}
 {{- range .Values.openRoutes }}
+{{- $route := . }}
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: {{ required "route.name is required" .name }}-open-httproute
+  name: {{ include "chorus-gateway.openHTTPRouteName" . }}
   namespace: {{ $.Values.gateway.namespace }}
   labels:
     {{- include "chorus-gateway.labels" $ | nindent 4 }}
@@ -160,21 +131,19 @@ spec:
     - {{ required "route.hostname is required" .hostname | quote }}
   rules:
     {{- if .redirectPath }}
-    {{- /* Redirect on exact "/" — Gateway API evaluates matches-bearing rules before
-         match-less ones, so this takes precedence over the catchall backendRefs below. */}}
+    {{- include "chorus-gateway.redirectOnRoot" . | nindent 4 }}
+    {{- end }}
+    {{- if .matches }}
+    {{- range .matches }}
     - matches:
         - path:
-            type: Exact
-            value: /
-      filters:
-        - type: RequestRedirect
-          requestRedirect:
-            path:
-              type: ReplaceFullPath
-              replaceFullPath: {{ .redirectPath | quote }}
+            type: PathPrefix
+            value: {{ required "match.pathPrefix is required" .pathPrefix | quote }}
+      backendRefs:
+        {{- include "chorus-gateway.backendRef" $route | nindent 8 }}
     {{- end }}
+    {{- else }}
     - backendRefs:
-        - name: {{ required "route.serviceName is required" .serviceName }}
-          namespace: {{ required "route.namespace is required" .namespace }}
-          port: {{ required "route.servicePort is required" .servicePort }}
+        {{- include "chorus-gateway.backendRef" . | nindent 8 }}
+    {{- end }}
 {{- end }}

--- a/charts/chorus-gateway/templates/securitypolicy.yaml
+++ b/charts/chorus-gateway/templates/securitypolicy.yaml
@@ -17,21 +17,17 @@ spec:
     {{- range .Values.internalRoutes }}
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
-      name: {{ .name }}-internal-httproute
+      name: {{ include "chorus-gateway.internalHTTPRouteName" . }}
     {{- end }}
     {{- range .Values.internalTcpRoutes }}
     - group: gateway.networking.k8s.io
       kind: TCPRoute
-      name: {{ .name }}-internal-tcproute
+      name: {{ include "chorus-gateway.internalTCPRouteName" . }}
     {{- end }}
   authorization:
     defaultAction: Deny
     rules:
-      - name: allow-workspace-pods
-        action: Allow
-        principal:
-          clientCIDRs:
-            - {{ required "podCIDR must be set to match the cluster's pod CIDR" .Values.podCIDR | quote }}
+      {{- include "chorus-gateway.podCIDRRule" (dict "name" "allow-workspace-pods" "action" "Allow" "podCIDR" .Values.podCIDR) | nindent 6 }}
 {{- end }}
 
 {{- /*
@@ -54,23 +50,19 @@ spec:
     {{- if not .extAuth }}
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
-      name: {{ .name }}-external-httproute
+      name: {{ include "chorus-gateway.externalHTTPRouteName" . }}
     {{- end }}
     {{- /* OAuth2 callback routes for extAuth routes — deny podCIDR */}}
     {{- if .extAuth }}
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
-      name: {{ .name }}-oauth2-httproute
+      name: {{ include "chorus-gateway.oauth2HTTPRouteName" . }}
     {{- end }}
     {{- end }}
   authorization:
     defaultAction: Allow
     rules:
-      - name: deny-workspace-pods
-        action: Deny
-        principal:
-          clientCIDRs:
-            - {{ required "podCIDR must be set to match the cluster's pod CIDR" .Values.podCIDR | quote }}
+      {{- include "chorus-gateway.podCIDRRule" (dict "name" "deny-workspace-pods" "action" "Deny" "podCIDR" .Values.podCIDR) | nindent 6 }}
 {{- end }}
 
 {{- /*
@@ -84,7 +76,7 @@ spec:
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:
-  name: {{ .name }}-extauth-securitypolicy
+  name: {{ include "chorus-gateway.extAuthSecurityPolicyName" . }}
   namespace: {{ $.Values.gateway.namespace }}
   labels:
     {{- include "chorus-gateway.labels" $ | nindent 4 }}
@@ -92,15 +84,11 @@ spec:
   targetRefs:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
-      name: {{ .name }}-external-httproute
+      name: {{ include "chorus-gateway.externalHTTPRouteName" . }}
   authorization:
     defaultAction: Allow
     rules:
-      - name: deny-workspace-pods
-        action: Deny
-        principal:
-          clientCIDRs:
-            - {{ required "podCIDR must be set to match the cluster's pod CIDR" $.Values.podCIDR | quote }}
+      {{- include "chorus-gateway.podCIDRRule" (dict "name" "deny-workspace-pods" "action" "Deny" "podCIDR" $.Values.podCIDR) | nindent 6 }}
   extAuth:
     failOpen: false
     headersToExtAuth:

--- a/charts/chorus-gateway/templates/tcproutes.yaml
+++ b/charts/chorus-gateway/templates/tcproutes.yaml
@@ -3,7 +3,7 @@
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TCPRoute
 metadata:
-  name: {{ required "tcpRoute.name is required" .name }}-internal-tcproute
+  name: {{ include "chorus-gateway.internalTCPRouteName" . }}
   namespace: {{ $.Values.gateway.namespace }}
   labels:
     {{- include "chorus-gateway.labels" $ | nindent 4 }}
@@ -13,7 +13,5 @@ spec:
       sectionName: tcp-{{ required "tcpRoute.gatewayPort is required" .gatewayPort | toString }}
   rules:
     - backendRefs:
-        - name: {{ required "tcpRoute.serviceName is required" .serviceName }}
-          namespace: {{ required "tcpRoute.namespace is required" .namespace }}
-          port: {{ required "tcpRoute.servicePort is required" .servicePort }}
+        {{- include "chorus-gateway.backendRef" . | nindent 8 }}
 {{- end }}

--- a/charts/chorus-gateway/templates/tcproutes.yaml
+++ b/charts/chorus-gateway/templates/tcproutes.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   parentRefs:
     - name: {{ $.Values.gateway.name }}
-      sectionName: tcp-{{ required "tcpRoute.gatewayPort is required" .gatewayPort | toString }}
+      sectionName: tcp-{{ required "gatewayPort is required" .gatewayPort | toString }}
   rules:
     - backendRefs:
         {{- include "chorus-gateway.backendRef" . | nindent 8 }}

--- a/charts/chorus-gateway/values.yaml
+++ b/charts/chorus-gateway/values.yaml
@@ -105,6 +105,9 @@ externalRoutes: []
 # Each entry creates an HTTPRoute and ReferenceGrant.
 # Must be set in environment values.
 #
+# Optional: matches (path-restricted, e.g. only /v2 and /service/token open
+# on a hostname that is otherwise served by an externalRoute catchall).
+#
 # Example:
 #   openRoutes:
 #     - name: auth

--- a/charts/chorus-gateway/values.yaml
+++ b/charts/chorus-gateway/values.yaml
@@ -98,6 +98,14 @@ internalAccessDeniedHTML: |-
 #         serviceName: prometheus-oauth2-proxy
 #         namespace: prometheus
 #         servicePort: 80
+#     # Restrict only /admin on a hostname otherwise served by an openRoute catchall.
+#     - name: auth-admin
+#       hostname: auth.chorus-tre.local
+#       namespace: keycloak
+#       serviceName: keycloak
+#       servicePort: 80
+#       matches:
+#         - pathPrefix: /admin
 externalRoutes: []
 
 # Open routes — accessible from both workspace pods and external browsers.
@@ -115,6 +123,16 @@ externalRoutes: []
 #       namespace: keycloak
 #       serviceName: keycloak
 #       servicePort: 80
+#     # Expose only /v2 and /service/token on a hostname otherwise served by
+#     # an externalRoute catchall (so pods can pull images, browsers get the UI).
+#     - name: harbor-registry
+#       hostname: harbor.chorus-tre.local
+#       namespace: harbor
+#       serviceName: harbor
+#       servicePort: 80
+#       matches:
+#         - pathPrefix: /v2
+#         - pathPrefix: /service/token
 openRoutes: []
 
 # Internal TCP routes — workspace pods only (SecurityPolicy allows podCIDR).

--- a/charts/chorus-gateway/values.yaml
+++ b/charts/chorus-gateway/values.yaml
@@ -70,6 +70,9 @@ internalAccessDeniedHTML: |-
 # Each entry creates an HTTPRoute and ReferenceGrant.
 # Must be set in environment values.
 #
+# Optional: matches (path-restricted, e.g. restrict only /admin on a hostname
+# that is otherwise served by an openRoute catch-all).
+#
 # Example:
 #   externalRoutes:
 #     # Full backend API — browsers only. Combine with the backend-idp internalRoute above


### PR DESCRIPTION
## Path-restricted external routes

Extends \`externalRoutes\` entries with an optional \`matches\` field (same shape as \`internalRoutes\`), rendering the HTTPRoute with one rule per matching path prefix instead of a catchall.

Use case: a hostname is already served by an \`openRoute\` catchall (so workspace pods and browsers both reach it), but a specific subpath should be browser-only. Example: \`auth.int.chorus-tre.ch\` served openly for OIDC endpoints, but \`/admin\` restricted to external browsers via SecurityPolicy.

The paired env change restricts the Keycloak admin console path to browsers-only.

Depends on chorus-tre #704 merging first (this PR is branched from #704's chain).