### PR TITLE
feat(gitlab): enable OmniAuth OIDC by default (0.0.9)

### DIFF
--- a/charts/gitlab/Chart.yaml
+++ b/charts/gitlab/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Web-based Git-repository manager with wiki and issue-tracking features.
 name: gitlab
-version: 0.0.8
+version: 0.0.9
 dependencies:
   - name: gitlab
     version: 9.9.3

--- a/charts/gitlab/values.yaml
+++ b/charts/gitlab/values.yaml
@@ -61,7 +61,7 @@ gitlab:
       omniauth:
         enabled: true
         allowSingleSignOn: ["openid_connect"]
-        blockAutoCreatedUsers: false
+        blockAutoCreatedUsers: true
         autoLinkUser: ["openid_connect"]
         providers:
           - secret: gitlab-oidc-secret

--- a/charts/gitlab/values.yaml
+++ b/charts/gitlab/values.yaml
@@ -59,7 +59,13 @@ gitlab:
       packages:
         enabled: false
       omniauth:
-        enabled: false
+        enabled: true
+        allowSingleSignOn: ["openid_connect"]
+        blockAutoCreatedUsers: false
+        autoLinkUser: ["openid_connect"]
+        providers:
+          - secret: gitlab-oidc-secret
+            key: provider
       smtp:
         enabled: false
 


### PR DESCRIPTION
## GitLab OmniAuth OIDC enabled by default

Flips \`gitlab.global.appConfig.omniauth\` default from \`enabled: false\` to \`enabled: true\`, wired to a standard provider Secret named \`gitlab-oidc-secret\` with key \`provider\`. Each env that deploys GitLab creates that Secret with the env-specific OIDC JSON blob (issuer, client credentials, redirect URI).

\`blockAutoCreatedUsers: true\` is kept as the default so new OIDC users land blocked; an admin must activate them. \`autoLinkUser: ["openid_connect"]\` links OIDC identities to existing GitLab accounts by verified email; this is only safe when the upstream IDP guarantees verified, non-forgeable email claims (the case for the CHORUS backend IDP).

Verified with \`helm template\` — the rendered gitlab.rb includes \`block_auto_created_users: true\`, \`auto_link_user: ["openid_connect"]\`, and reads \`providers\` from \`/etc/gitlab/omniauth/gitlab-oidc-secret/provider\`.

## Pre-deploy (per env, before bumping the chart version in env/config.json)

Create \`gitlab-oidc-secret\` in the \`gitlab\` namespace with a \`provider\` key holding the OmniAuth JSON blob. Without this Secret present, Webservice and Sidekiq pods will fail to roll out.

\`\`\`
kubectl -n gitlab create secret generic gitlab-oidc-secret --from-file=provider=/tmp/gitlab-oidc-provider.json
\`\`\`

Where \`/tmp/gitlab-oidc-provider.json\` looks like:

\`\`\`json
{
  "name": "openid_connect",
  "label": "CHORUS",
  "args": {
    "scope": ["openid", "profile", "email"],
    "response_type": "code",
    "issuer": "https://backend.<env>.chorus-tre.ch/openid-connect",
    "discovery": true,
    "client_auth_method": "basic",
    "uid_field": "preferred_username",
    "client_options": {
      "identifier": "gitlab",
      "secret": "<CLIENT_SECRET>",
      "redirect_uri": "https://gitlab.<env>.chorus-tre.ch/users/auth/openid_connect/callback"
    }
  }
}
\`\`\`

Replace \`<env>\` with the target cluster and \`<CLIENT_SECRET>\` with the client secret registered at the backend IDP for the \`gitlab\` client.

## Env bump

chorus-int is the only env currently running GitLab. The follow-up env bump to \`0.0.9\` lives in a separate PR on the environments repo (https://github.com/CHORUS-TRE/environments/pull/1655) and should be merged after the Secret is provisioned.

## Ordering

1. Create \`gitlab-oidc-secret\` in the \`gitlab\` namespace (command above).
2. Merge this chart PR and wait for the chart to publish.
3. Merge the env PR that bumps \`chorus-int/gitlab/config.json\` to 0.0.9.
4. ArgoCD syncs, Webservice rolls out, OIDC becomes available at \`https://gitlab.<env>.chorus-tre.ch/users/sign_in\`.