### PR TITLE
fix(keycloak): wire juicefs-dashboard into realm + ConfigMap (0.0.45)

### DIFF
--- a/charts/keycloak/Chart.yaml
+++ b/charts/keycloak/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Keycloak is a high performance Java-based identity and access management solution. It lets developers add an authentication layer to their applications with minimum effort.
 name: keycloak
-version: 0.0.44
+version: 0.0.45
 dependencies:
   - name: keycloak
     version: 24.5.2

--- a/charts/keycloak/files/realm/remote/infra-realm.yaml
+++ b/charts/keycloak/files/realm/remote/infra-realm.yaml
@@ -169,6 +169,39 @@ clients:
       - "offline_access"
       - "groups"
     access: {}
+  - clientId: "juicefs-dashboard"
+    name: "JuiceFS Dashboard"
+    rootUrl: "$(JUICEFS_DASHBOARD_ROOT_URL)"
+    adminUrl: "$(JUICEFS_DASHBOARD_ADMIN_URL)"
+    baseUrl: "$(JUICEFS_DASHBOARD_BASE_URL)"
+    secret: "$(JUICEFS_DASHBOARD_CLIENT_SECRET)"
+    redirectUris: $(JUICEFS_DASHBOARD_REDIRECT_URIS)
+    webOrigins: $(JUICEFS_DASHBOARD_WEB_ORIGINS)
+    implicitFlowEnabled: true
+    directAccessGrantsEnabled: true
+    publicClient: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "false"
+      exclude.issuer.from.auth.response: "false"
+      backchannel.logout.session.required: "true"
+      client_credentials.use_refresh_token: "false"
+      display.on.consent.screen: "false"
+      oauth2.device.authorization.grant.enabled: "false"
+      backchannel.logout.revoke.offline.tokens: "false"
+      use.refresh.tokens: "true"
+      exclude.session.state.from.auth.response: "false"
+    defaultClientScopes:
+      - web-origins
+      - acr
+      - profile
+      - roles
+      - basic
+      - email
+    optionalClientScopes:
+      - "offline_access"
+      - "groups"
+    access: {}
   - clientId: "prometheus"
     name: "Prometheus"
     rootUrl: "$(PROMETHEUS_ROOT_URL)"

--- a/charts/keycloak/templates/client-config.yaml
+++ b/charts/keycloak/templates/client-config.yaml
@@ -52,6 +52,12 @@ data:
   HARBOR_BASE_URL: {{ .Values.client.harbor.baseUrl | quote }}
   HARBOR_REDIRECT_URIS: {{ .Values.client.harbor.redirectUris | quote }}
   HARBOR_WEB_ORIGINS: {{ .Values.client.harbor.webOrigins | quote }}
+  # juicefs-dashboard
+  JUICEFS_DASHBOARD_ROOT_URL: {{ index .Values.client "juicefs-dashboard" "rootUrl" | quote }}
+  JUICEFS_DASHBOARD_ADMIN_URL: {{ index .Values.client "juicefs-dashboard" "adminUrl" | quote }}
+  JUICEFS_DASHBOARD_BASE_URL: {{ index .Values.client "juicefs-dashboard" "baseUrl" | quote }}
+  JUICEFS_DASHBOARD_REDIRECT_URIS: {{ index .Values.client "juicefs-dashboard" "redirectUris" | quote }}
+  JUICEFS_DASHBOARD_WEB_ORIGINS: {{ index .Values.client "juicefs-dashboard" "webOrigins" | quote }}
   # prometheus
   PROMETHEUS_ROOT_URL: {{ .Values.client.prometheus.rootUrl | quote }}
   PROMETHEUS_ADMIN_URL: {{ .Values.client.prometheus.adminUrl | quote }}


### PR DESCRIPTION
## juicefs-dashboard client provisioning fix

PR #706 added \`juicefs-dashboard\` to \`charts/keycloak/values.yaml\` under \`client:\`, but neither the \`infra-realm.yaml\` file nor the \`client-config.yaml\` ConfigMap iterates over that map — they hardcode each client. So keycloak-config-cli had nothing to act on and the Keycloak client was never created.

Adds the missing plumbing:
- \`files/realm/remote/infra-realm.yaml\`: new \`juicefs-dashboard\` client block (mirrors harbor/prometheus)
- \`templates/client-config.yaml\`: new \`JUICEFS_DASHBOARD_*\` env vars so the \`$(…)\` substitutions in the realm file resolve

### Pre-deploy
Before ArgoCD syncs this, add \`JUICEFS_DASHBOARD_CLIENT_SECRET\` to the existing \`keycloak-client-secret\` Secret:

```
kubectl -n keycloak get secret keycloak-client-secret -o json \
  | jq '.data.JUICEFS_DASHBOARD_CLIENT_SECRET = ("<RANDOM_SECRET>" | @base64)' \
  | kubectl apply -f -
```

Generate with \`openssl rand -base64 32\` or similar. This value must also land in \`juicefs-dashboard-oidc-secret\` in \`envoy-gateway-system\` (see env PR #1654).