### PR TITLE
feat(chorus-gateway): support OIDC on openRoutes (no podCIDR rule)

### DIFF
--- a/charts/chorus-gateway/Chart.yaml
+++ b/charts/chorus-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: chorus-gateway
 description: Envoy Gateway HTTPRoutes and SecurityPolicies for CHORUS services
-version: 0.0.16
+version: 0.0.17
 maintainers:
   - name: iDmple
     email: nathalie.casati@chuv.ch

--- a/charts/chorus-gateway/templates/_helpers.tpl
+++ b/charts/chorus-gateway/templates/_helpers.tpl
@@ -85,3 +85,11 @@ multiple templates. All take a route map and return "<route.name>-<suffix>".
 {{- define "chorus-gateway.extAuthSecurityPolicyName" -}}
 {{- printf "%s-extauth-securitypolicy" (required "name is required" .name) -}}
 {{- end }}
+
+{{- define "chorus-gateway.externalOIDCSecurityPolicyName" -}}
+{{- printf "%s-external-oidc-securitypolicy" (required "name is required" .name) -}}
+{{- end }}
+
+{{- define "chorus-gateway.openOIDCSecurityPolicyName" -}}
+{{- printf "%s-open-oidc-securitypolicy" (required "name is required" .name) -}}
+{{- end }}

--- a/charts/chorus-gateway/templates/oidcsecuritypolicy.yaml
+++ b/charts/chorus-gateway/templates/oidcsecuritypolicy.yaml
@@ -1,15 +1,20 @@
 {{- /*
-  OIDC SecurityPolicies — one per external route with `oidc` configured.
+  OIDC SecurityPolicies — one per route with `oidc` configured.
   Envoy Gateway's native OIDC filter handles the full authorization-code
   flow: redirect browser to the IdP, exchange the code server-side, set a
   session cookie, intercept callbacks. The route's upstream service never
   sees unauthenticated traffic.
 
+  Supported on `externalRoutes` (with a "deny workspace pods" rule based on
+  podCIDR) and on `openRoutes` (no CIDR rule — used on clusters without
+  workspaces, e.g. CI clusters).
+
   `oidc.clientSecretName` (values) must reference a Secret in the gateway
   namespace containing a `client-secret` key — Envoy Gateway reads that
   fixed key name from the Secret.
 */}}
-{{- range .Values.externalRoutes }}
+{{- range $kind, $routes := dict "external" .Values.externalRoutes "open" .Values.openRoutes }}
+{{- range $routes }}
 {{- if and .oidc (ne (.oidc.enabled | toString) "false") }}
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
@@ -23,7 +28,7 @@ spec:
   targetRefs:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
-      name: {{ include "chorus-gateway.externalHTTPRouteName" . }}
+      name: {{ if eq $kind "external" }}{{ include "chorus-gateway.externalHTTPRouteName" . }}{{ else }}{{ include "chorus-gateway.openHTTPRouteName" . }}{{ end }}
   oidc:
     provider:
       backendRefs:
@@ -50,9 +55,12 @@ spec:
       - {{ . | quote }}
       {{- end }}
     {{- end }}
+  {{- if eq $kind "external" }}
   authorization:
     defaultAction: Allow
     rules:
       {{- include "chorus-gateway.podCIDRRule" (dict "name" "deny-workspace-pods" "action" "Deny" "podCIDR" $.Values.podCIDR) | nindent 6 }}
+  {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/chorus-gateway/templates/oidcsecuritypolicy.yaml
+++ b/charts/chorus-gateway/templates/oidcsecuritypolicy.yaml
@@ -20,7 +20,7 @@
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:
-  name: {{ .name }}-oidc-securitypolicy
+  name: {{ if eq $kind "external" }}{{ include "chorus-gateway.externalOIDCSecurityPolicyName" . }}{{ else }}{{ include "chorus-gateway.openOIDCSecurityPolicyName" . }}{{ end }}
   namespace: {{ $.Values.gateway.namespace }}
   labels:
     {{- include "chorus-gateway.labels" $ | nindent 4 }}

--- a/charts/chorus-gateway/templates/referencegrants.yaml
+++ b/charts/chorus-gateway/templates/referencegrants.yaml
@@ -14,7 +14,7 @@
 {{- end }}
 
 {{- $oidcNamespaces := dict }}
-{{- range .Values.externalRoutes }}
+{{- range concat .Values.externalRoutes .Values.openRoutes }}
 {{- if and .oidc (ne (.oidc.enabled | toString) "false") (.oidc.provider) }}
 {{- $_ := set $oidcNamespaces .oidc.provider.namespace true }}
 {{- end }}

--- a/charts/chorus-gateway/values.yaml
+++ b/charts/chorus-gateway/values.yaml
@@ -157,6 +157,27 @@ externalRoutes: []
 #       matches:
 #         - pathPrefix: /v2
 #         - pathPrefix: /service/token
+#     # OIDC on an openRoute — for Build cluster, where CHORUS isn't deployed.
+#     # Envoy Gateway runs the full Keycloak login flow before any request reaches
+#     # prometheus. No podCIDR rule is emitted (no workspaces to isolate).
+#     - name: prometheus
+#       hostname: prometheus.build.chorus-tre.local
+#       namespace: prometheus
+#       serviceName: chorus-build-kube-promethe-prometheus
+#       servicePort: 9090
+#       oidc:
+#         provider:
+#           serviceName: chorus-build-keycloak
+#           namespace: keycloak
+#           servicePort: 80
+#         issuer: https://auth.build.chorus-tre.local/realms/infra
+#         authorizationEndpoint: https://auth.build.chorus-tre.local/realms/infra/protocol/openid-connect/auth
+#         tokenEndpoint: https://auth.build.chorus-tre.local/realms/infra/protocol/openid-connect/token
+#         clientID: prometheus
+#         clientSecretName: prometheus-oidc-secret
+#         redirectURL: https://prometheus.build.chorus-tre.local/oauth2/callback
+#         logoutPath: /oauth2/logout
+#         scopes: [openid, email]
 openRoutes: []
 
 # Internal TCP routes — workspace pods only (SecurityPolicy allows podCIDR).


### PR DESCRIPTION
## Allow native Envoy OIDC on `openRoutes`

Today the OIDC `SecurityPolicy` template iterates only `externalRoutes`, and always emits a "deny workspace pods" rule keyed off `podCIDR`. That means clusters without a Chorus workspace deployment (e.g. CI clusters like chorus-build) can't use OIDC on a route without inventing a dummy podCIDR.

This change extends OIDC support to `openRoutes`:

- `oidcsecuritypolicy.yaml` now iterates both `externalRoutes` and `openRoutes`. Each route's SecurityPolicy targets the correct HTTPRoute name via the existing `externalHTTPRouteName` / `openHTTPRouteName` helpers.
- The `authorization` block (with the podCIDR-based "deny workspace pods" rule) is emitted only for `externalRoutes`. `openRoutes` get the OIDC filter alone — Envoy still requires a successful Keycloak login, but no CIDR rule is added (none is needed; `openRoutes` have no CIDR-based posture by definition).
- `referencegrants.yaml` now also collects OIDC provider namespaces from `openRoutes`, so cross-namespace `oidc.provider.backendRefs` work for openRoute OIDC too.
- Per-route OIDC SecurityPolicy names now include the route kind (`<name>-external-oidc-securitypolicy`, `<name>-open-oidc-securitypolicy`) via two new helpers `externalOIDCSecurityPolicyName` / `openOIDCSecurityPolicyName`. Matches the existing route-name helper convention and avoids name collisions if the same route name appears in both lists.
- `values.yaml` documentation gains an OIDC-on-openRoute example using a chorus-build pattern (Build cluster, where CHORUS isn't deployed).

Chart bump `0.0.16 → 0.0.17`. No change to existing externalRoute or openRoute behavior — only adds a new combination.