### PR TITLE
fix(i2b2-wildfly): support node-local-dns and CoreDNS in CNP DNS egress

### DIFF
--- a/charts/i2b2-wildfly/Chart.yaml
+++ b/charts/i2b2-wildfly/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.9
+version: 0.0.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/i2b2-wildfly/templates/ciliumnetworkpolicy.yaml
+++ b/charts/i2b2-wildfly/templates/ciliumnetworkpolicy.yaml
@@ -31,19 +31,30 @@ spec:
   # Note: CiliumNetworkPolicy uses different format than K8s NetworkPolicy
   # For L7 WAF mode, define specific Cilium egress rules in environment-specific values
   egress:
-  # Always allow DNS resolution.
-  # Use kube-dns entity to auto-detect DNS infrastructure (kube-dns or node-local-dns).
-  - toEntities:
-    - kube-dns
+  # Allow DNS to in-cluster CoreDNS pods (clusters without node-local-dns).
+  # Targets the kube-dns Service backing pods by their label.
+  - toEndpoints:
+    - matchLabels:
+        "k8s:io.kubernetes.pod.namespace": kube-system
+        app: coredns
     toPorts:
     - ports:
       - port: "53"
         protocol: UDP
       - port: "53"
         protocol: TCP
-      rules:
-        dns:
-        - matchPattern: "*"
+  # Allow DNS to node-local-dns (host network, link-local IP 169.254.x.x).
+  # Cilium classifies that link-local IP as the "world" entity (not "host" and
+  # not the node-local-dns pod identity, since the pod runs hostNetwork=true).
+  # Bounded to port 53 — does not allow general external egress.
+  - toEntities:
+    - world
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
   {{- if .Values.networkPolicy.egress }}
     {{- toYaml .Values.networkPolicy.egress | nindent 2 }}
   {{- end }}


### PR DESCRIPTION
## Fix DNS egress in i2b2-wildfly CiliumNetworkPolicy

The 0.0.9 CNP egress used `toEntities: kube-dns`, which is not a valid Cilium entity. When `enabled_l7_waf: true`, Cilium silently treats the rule as having no destinations → DNS lookups from the wildfly pod are blocked → "unknown host".

Empirical testing on chorus-demo (which runs both CoreDNS and node-local-dns) showed:

| Egress rule | Result |
|---|---|
| `toEndpoints: app=node-local-dns` (host-network pod) | Blocked — Cilium maps the link-local destination IP to its own identity, not to the pod's labels |
| `toEntities: [host]` | Blocked |
| `toEntities: [unmanaged]` | Blocked |
| `toEntities: [world]` | Allowed |
| `toEndpoints: app=coredns` | Allowed (in-cluster CoreDNS path, used on chorus-int where node-local-dns isn't deployed) |

Pod's `/etc/resolv.conf` on chorus-demo points at `nameserver 169.254.20.10` (node-local-dns link-local). Cilium classifies that IP as the `world` entity since it's not in any pod CIDR and the binding pod runs `hostNetwork: true`.

The fix replaces the bogus rule with two egress rules:

- `toEndpoints: kube-system + app=coredns` on port 53 — covers in-cluster CoreDNS (any cluster without node-local-dns).
- `toEntities: [world]` on port 53 — covers node-local-dns link-local destination. Bounded to port 53 only; does not open general external egress.

Both rules are gated by the policy's `endpointSelector` so only `i2b2-wildfly` pods can use them.

Bumps chart `0.0.9 → 0.0.10`.

The K8s `NetworkPolicy` template (used when `enabled_l7_waf: false`) is unchanged — it already opens port 53 to any destination, which works for both DNS modes.