### PR TITLE
feat(chorus-gateway): support gRPC services via openGrpcRoutes (GRPCRoute)

### DIFF
--- a/charts/chorus-gateway/Chart.yaml
+++ b/charts/chorus-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: chorus-gateway
 description: Envoy Gateway HTTPRoutes and SecurityPolicies for CHORUS services
-version: 0.0.17
+version: 0.0.18
 maintainers:
   - name: iDmple
     email: nathalie.casati@chuv.ch

--- a/charts/chorus-gateway/Chart.yaml
+++ b/charts/chorus-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: chorus-gateway
-description: Envoy Gateway HTTPRoutes and SecurityPolicies for CHORUS services
+description: Envoy Gateway routes and SecurityPolicies for CHORUS services
 version: 0.0.18
 maintainers:
   - name: iDmple

--- a/charts/chorus-gateway/templates/_helpers.tpl
+++ b/charts/chorus-gateway/templates/_helpers.tpl
@@ -82,6 +82,10 @@ multiple templates. All take a route map and return "<route.name>-<suffix>".
 {{- printf "%s-internal-tcproute" (required "name is required" .name) -}}
 {{- end }}
 
+{{- define "chorus-gateway.openGRPCRouteName" -}}
+{{- printf "%s-open-grpcroute" (required "name is required" .name) -}}
+{{- end }}
+
 {{- define "chorus-gateway.extAuthSecurityPolicyName" -}}
 {{- printf "%s-extauth-securitypolicy" (required "name is required" .name) -}}
 {{- end }}

--- a/charts/chorus-gateway/templates/grpcroutes.yaml
+++ b/charts/chorus-gateway/templates/grpcroutes.yaml
@@ -1,0 +1,24 @@
+{{- /*
+  Open gRPC routes — accessible from anywhere, no SecurityPolicy restriction.
+  Used for services that publish a gRPC API (e.g. argo-cd's gRPC server for
+  the `argocd` CLI) on a dedicated hostname. Backend Service must speak
+  gRPC over HTTP/2 (typical for argo-cd-server, gRPC microservices, etc.).
+*/}}
+{{- range .Values.openGrpcRoutes }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GRPCRoute
+metadata:
+  name: {{ include "chorus-gateway.openGRPCRouteName" . }}
+  namespace: {{ $.Values.gateway.namespace }}
+  labels:
+    {{- include "chorus-gateway.labels" $ | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ $.Values.gateway.name }}
+  hostnames:
+    - {{ required "hostname is required" .hostname | quote }}
+  rules:
+    - backendRefs:
+        {{- include "chorus-gateway.backendRef" . | nindent 8 }}
+{{- end }}

--- a/charts/chorus-gateway/templates/referencegrants.yaml
+++ b/charts/chorus-gateway/templates/referencegrants.yaml
@@ -25,7 +25,7 @@
   hosts a backend Service referenced from the gateway namespace.
 */}}
 {{- $grantNamespaces := dict }}
-{{- range concat .Values.internalRoutes .Values.externalRoutes .Values.openRoutes .Values.internalTcpRoutes }}
+{{- range concat .Values.internalRoutes .Values.externalRoutes .Values.openRoutes .Values.internalTcpRoutes .Values.openGrpcRoutes }}
 {{- $_ := set $grantNamespaces .namespace true }}
 {{- end }}
 {{- range $ns, $_ := $extAuthNamespaces }}
@@ -51,6 +51,9 @@ spec:
       namespace: {{ $.Values.gateway.namespace }}
     - group: gateway.networking.k8s.io
       kind: TCPRoute
+      namespace: {{ $.Values.gateway.namespace }}
+    - group: gateway.networking.k8s.io
+      kind: GRPCRoute
       namespace: {{ $.Values.gateway.namespace }}
     {{- if or (hasKey $extAuthNamespaces $ns) (hasKey $oidcNamespaces $ns) }}
     - group: gateway.envoyproxy.io

--- a/charts/chorus-gateway/templates/tcproutes.yaml
+++ b/charts/chorus-gateway/templates/tcproutes.yaml
@@ -1,3 +1,8 @@
+{{- /*
+  Internal TCP routes — workspace pods only (SecurityPolicy allows podCIDR).
+  Each entry forwards a Gateway TCP listener (gatewayPort) to the backend Service.
+  Used for non-HTTP TCP services like gitlab-shell SSH.
+*/}}
 {{- range .Values.internalTcpRoutes }}
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2

--- a/charts/chorus-gateway/values.yaml
+++ b/charts/chorus-gateway/values.yaml
@@ -197,7 +197,11 @@ internalTcpRoutes: []
 
 # Open gRPC routes — accessible from anywhere, no SecurityPolicy restriction.
 # Each entry creates a GRPCRoute and ReferenceGrant. Backend Service must speak
-# gRPC over HTTP/2 (e.g. argo-cd-server, gRPC microservices).
+# gRPC over HTTP/2 (e.g. argo-cd-server, gRPC microservices). To make Envoy use
+# HTTP/2 to the backend, the Service port should advertise it via
+# `appProtocol: kubernetes.io/h2c` (cleartext) or `appProtocol: kubernetes.io/grpc`
+# (TLS) — without this Envoy may default to HTTP/1.1 and the backend will
+# reject framed gRPC.
 #
 # Example — argo-cd's gRPC API on a dedicated hostname (Build cluster, where CHORUS isn't deployed):
 #   openGrpcRoutes:

--- a/charts/chorus-gateway/values.yaml
+++ b/charts/chorus-gateway/values.yaml
@@ -195,6 +195,19 @@ openRoutes: []
 #       gatewayPort: 22
 internalTcpRoutes: []
 
+# Open gRPC routes — accessible from anywhere, no SecurityPolicy restriction.
+# Each entry creates a GRPCRoute and ReferenceGrant. Backend Service must speak
+# gRPC over HTTP/2 (e.g. argo-cd-server, gRPC microservices).
+#
+# Example — argo-cd's gRPC API on a dedicated hostname (Build cluster, where CHORUS isn't deployed):
+#   openGrpcRoutes:
+#     - name: argo-cd-grpc
+#       hostname: grpc.argo-cd.build.chorus-tre.local
+#       namespace: argocd
+#       serviceName: chorus-build-argo-cd-argocd-server
+#       servicePort: 443
+openGrpcRoutes: []
+
 # Internal shell services — each entry creates a CiliumNetworkPolicy restricting ingress on the
 # service container port to Envoy pods only (defense-in-depth for internal TCP services).
 # Envoy terminates the client TCP connection and opens a new one to the service pod,


### PR DESCRIPTION
## Add gRPC route support to chorus-gateway

The chart only renders `HTTPRoute` and `TCPRoute` today. Migrating services that publish a gRPC API on a dedicated hostname (e.g. argo-cd's `grpc.argo-cd.<domain>`) needs a `GRPCRoute` so Envoy proxies HTTP/2 framed gRPC instead of treating it as plain HTTP.

This change:

- Adds `templates/grpcroutes.yaml` — iterates `openGrpcRoutes` and renders one `GRPCRoute` per entry. Same minimal shape as openRoutes (name, hostname, namespace, serviceName, servicePort).
- Adds `chorus-gateway.openGRPCRouteName` helper in `_helpers.tpl` (returns `<name>-open-grpcroute`), matching the existing route-name helper convention.
- Extends `referencegrants.yaml` to include `openGrpcRoutes` namespaces, and adds `GRPCRoute` to the `from` kinds on every ReferenceGrant so cross-namespace backendRefs from a GRPCRoute are allowed.
- Adds an `openGrpcRoutes:` example in `values.yaml` showing argo-cd's gRPC API (chorus-build pattern, where CHORUS isn't deployed).

`openGrpcRoutes` follows the "open" naming convention (no SecurityPolicy restriction). If we ever need restricted gRPC, an `internalGrpcRoutes` / `externalGrpcRoutes` could be added later in the same shape.

Chart bump `0.0.17 → 0.0.18`. No change to existing route behavior — only adds a new route type.