### PR TITLE
feat(keycloakx): new chart wrapping codecentric/keycloakx

### DIFF
--- a/charts/keycloakx/Chart.lock
+++ b/charts/keycloakx/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: keycloakx
+  repository: https://codecentric.github.io/helm-charts
+  version: 7.1.11
+digest: sha256:6907fc6c2270479d491609388c91016d96cb9ffa4a237a945be547f026addcab
+generated: "2026-04-28T10:30:19.446632+02:00"

--- a/charts/keycloakx/Chart.yaml
+++ b/charts/keycloakx/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+description: Keycloak deployed via the codecentric/keycloakx chart, aliased to `keycloak`.
+name: keycloakx
+version: 0.0.1
+dependencies:
+  - name: keycloakx
+    version: 7.1.11
+    repository: https://codecentric.github.io/helm-charts
+    alias: keycloak
+
+maintainers:
+  - name: floriansipp
+    email: florian.sipp@chuv.ch
+  - name: iDmple
+    email: nathalie.casati@chuv.ch

--- a/charts/keycloakx/Chart.yaml
+++ b/charts/keycloakx/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-description: Keycloak deployed via the codecentric/keycloakx chart, aliased to `keycloak`.
+description: Keycloak.X - Open Source Identity and Access Management for Modern Applications and Services
 name: keycloakx
 version: 0.0.1
 dependencies:

--- a/charts/keycloakx/README.md
+++ b/charts/keycloakx/README.md
@@ -1,0 +1,74 @@
+# Keycloak (keycloakx)
+
+Helm chart wrapping the upstream [keycloakx][] (aliased as `keycloak`).
+
+Realm import is performed by a chart-owned `keycloak-config-cli` Job
+(`templates/keycloak-config-cli-job.yaml`) running as a Helm/Argo PostSync hook.
+
+[keycloakx]: https://github.com/codecentric/helm-charts/tree/master/charts/keycloakx
+
+
+## Required Secrets
+
+### Client Credentials Secret
+
+A Kubernetes Secret containing the client credentials for the realms. The name is configurable via `.Values.client.existingSecret` (default `keycloak-client-secret`).
+
+**Build cluster secret example**
+
+Realms: master and infra
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-client-secret
+stringData:
+  GOOGLE_CLIENT_ID: "my-google-client-id"
+  GOOGLE_CLIENT_SECRET: "my-google-client-secret"
+  ALERTMANAGER_CLIENT_SECRET: "my-alertmanager-secret"
+  ARGO_CD_CLIENT_SECRET: "my-argo-cd-secret"
+  ARGO_WORKFLOWS_CLIENT_SECRET: "my-argo-workflows-secret"
+  GRAFANA_CLIENT_SECRET: "my-grafana-secret"
+  HARBOR_CLIENT_SECRET: "my-harbor-secret"
+  PROMETHEUS_CLIENT_SECRET: "my-prometheus-secret"
+type: Opaque
+```
+
+**Remote cluster secret example**
+
+Realms: master, infra and chorus
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-client-secret
+stringData:
+  GOOGLE_CLIENT_ID: "my-google-client-id"
+  GOOGLE_CLIENT_SECRET: "my-google-client-secret"
+  ALERTMANAGER_CLIENT_SECRET: "my-alertmanager-secret"
+  GRAFANA_CLIENT_SECRET: "my-grafana-secret"
+  HARBOR_CLIENT_SECRET: "my-harbor-secret"
+  MATOMO_CLIENT_SECRET: "my-matomo-secret"
+  PROMETHEUS_CLIENT_SECRET: "my-prometheus-secret"
+  CHORUS_CLIENT_SECRET: "my-chorus-client-secret"
+type: Opaque
+```
+
+### Remote State Encryption Secret
+
+Enables remote state in encrypted format. If unset, state is stored in plain.
+Generate a key with `openssl rand -hex 32` (must be an **even** number of characters).
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-remotestate-encryption-key
+stringData:
+  encryptionKey: "change-me"
+type: Opaque
+```
+
+## Keycloak realm normalization
+
+When moving from an unmanaged keycloak instance, refer to the [keycloak-config-cli normalize docs](https://github.com/adorsys/keycloak-config-cli/blob/main/docs/NORMALIZE.md).

--- a/charts/keycloakx/README.md
+++ b/charts/keycloakx/README.md
@@ -8,6 +8,22 @@ Realm import is performed by a chart-owned `keycloak-config-cli` Job
 [keycloakx]: https://github.com/codecentric/helm-charts/tree/master/charts/keycloakx
 
 
+## Migrating from `charts/keycloak` (bitnami)
+
+- `keycloakConfigCli.*` is top-level here. The bitnami chart nested it under
+  `keycloak:` (the subchart alias), so any overrides need to be moved up one
+  level — silent fallthrough otherwise.
+- Admin and DB credentials are read from `keycloak-secret/adminPassword` and
+  `keycloak-db-secret/password`. chorus-tre envs already point at these names;
+  consumers porting from stock bitnami defaults (`keycloak-admin-postgres/...`)
+  need to rename or recreate.
+- Realm and client ConfigMaps are now release-prefixed
+  (`<release>-realm-config`, `<release>-client-config`) and consumed only by
+  this chart's templates.
+- `adminIngress` is gone. For separate admin URL routing, set
+  `KC_HOSTNAME_ADMIN` in `keycloak.extraEnv` (Keycloak 26 native).
+
+
 ## Required Secrets
 
 ### Client Credentials Secret

--- a/charts/keycloakx/files/realm/build/infra-realm.yaml
+++ b/charts/keycloakx/files/realm/build/infra-realm.yaml
@@ -1,0 +1,504 @@
+---
+realm: "infra"
+displayName: ""
+displayNameHtml: ""
+revokeRefreshToken: true
+enabled: true
+registrationAllowed: false
+roles:
+  client:
+    grafana:
+      - name: editor
+        description: ""
+        composite: false
+        clientRole: true
+        attributes: {}
+      - name: admin
+        description: ""
+        composite: false
+        clientRole: true
+        attributes: {}
+groups:
+  - name: "ArgoCDAdmins"
+    path: "/ArgoCDAdmins"
+    subGroups: []
+  - name: "ArgoWorkflowsAdmins"
+    path: "/ArgoWorkflowsAdmins"
+    subGroups: []
+  - name: "HarborAdmins"
+    path: "/HarborAdmins"
+    subGroups: []
+  - name: "Grafana"
+    path: "/Grafana"
+    subGroups:
+      - name: "Editors"
+        path: "/Grafana/Editors"
+        subGroups:
+          - name: "Administrators"
+            path: "/Grafana/Editors/Administrators"
+            subGroups: []
+            realmRoles: []
+            clientRoles:
+              grafana:
+                - admin
+        realmRoles: []
+        clientRoles:
+          grafana:
+            - editor
+passwordPolicy: "length(8) and specialChars(1) and upperCase(1) and lowerCase(1) and\
+  \ digits(1) and notUsername and notEmail and notContainsUsername"
+webAuthnPolicySignatureAlgorithms:
+  - "ES256"
+  - "RS256"
+webAuthnPolicyPasswordlessSignatureAlgorithms:
+  - "ES256"
+  - "RS256"
+clients:
+  - clientId: "admin-cli"
+    name: "${client_admin-cli}"
+    redirectUris: []
+    webOrigins: []
+    standardFlowEnabled: false
+    directAccessGrantsEnabled: true
+    publicClient: true
+    frontchannelLogout: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "false"
+      client.use.lightweight.access.token.enabled: "true"
+    nodeReRegistrationTimeout: 0
+    access: {}
+  - clientId: "broker"
+    name: "${client_broker}"
+    redirectUris: []
+    webOrigins: []
+    bearerOnly: true
+    publicClient: false
+    frontchannelLogout: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "true"
+    fullScopeAllowed: false
+    nodeReRegistrationTimeout: 0
+    access: {}
+  - clientId: "realm-management"
+    name: "${client_realm-management}"
+    redirectUris: []
+    webOrigins: []
+    bearerOnly: true
+    publicClient: false
+    frontchannelLogout: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "true"
+    fullScopeAllowed: false
+    nodeReRegistrationTimeout: 0
+    access: {}
+  - clientId: "grafana"
+    name: "Grafana"
+    rootUrl: "$(GRAFANA_ROOT_URL)"
+    adminUrl: "$(GRAFANA_ADMIN_URL)"
+    baseUrl: "$(GRAFANA_BASE_URL)"
+    secret: "$(GRAFANA_CLIENT_SECRET)"
+    redirectUris: $(GRAFANA_REDIRECT_URIS)
+    webOrigins: $(GRAFANA_WEB_ORIGINS)
+    implicitFlowEnabled: true
+    directAccessGrantsEnabled: true
+    publicClient: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "false"
+      exclude.issuer.from.auth.response: "false"
+      backchannel.logout.session.required: "true"
+      client_credentials.use_refresh_token: "false"
+      display.on.consent.screen: "false"
+      oauth2.device.authorization.grant.enabled: "false"
+      backchannel.logout.revoke.offline.tokens: "false"
+      use.refresh.tokens: "true"
+      exclude.session.state.from.auth.response: "false"
+    protocolMappers:
+      - name: client roles
+        protocol: openid-connect
+        protocolMapper: oidc-usermodel-client-role-mapper
+        consentRequired: false
+        config:
+          introspection.token.claim: "true"
+          multivalued: "true"
+          userinfo.token.claim: "false"
+          user.attribute: foo
+          id.token.claim: "true"
+          lightweight.claim: "false"
+          access.token.claim: "true"
+          claim.name: roles
+          jsonType.label: String
+    defaultClientScopes:
+      - web-origins
+      - acr
+      - profile
+      - roles
+      - basic
+      - email
+    optionalClientScopes:
+      - "offline_access"
+      - "groups"
+    access: {}
+  - clientId: "harbor"
+    name: "Harbor"
+    rootUrl: "$(HARBOR_ROOT_URL)"
+    adminUrl: "$(HARBOR_ADMIN_URL)"
+    baseUrl: "$(HARBOR_BASE_URL)"
+    secret: "$(HARBOR_CLIENT_SECRET)"
+    redirectUris: $(HARBOR_REDIRECT_URIS)
+    webOrigins: $(HARBOR_WEB_ORIGINS)
+    implicitFlowEnabled: true
+    directAccessGrantsEnabled: true
+    publicClient: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "false"
+      exclude.issuer.from.auth.response: "false"
+      backchannel.logout.session.required: "true"
+      client_credentials.use_refresh_token: "false"
+      display.on.consent.screen: "false"
+      oauth2.device.authorization.grant.enabled: "false"
+      backchannel.logout.revoke.offline.tokens: "false"
+      use.refresh.tokens: "true"
+      exclude.session.state.from.auth.response: "false"
+    defaultClientScopes:
+      - web-origins
+      - acr
+      - profile
+      - roles
+      - basic
+      - email
+    optionalClientScopes:
+      - "offline_access"
+      - "groups"
+    access: {}
+  - clientId: "prometheus"
+    name: "Prometheus"
+    rootUrl: "$(PROMETHEUS_ROOT_URL)"
+    adminUrl: "$(PROMETHEUS_ADMIN_URL)"
+    baseUrl: "$(PROMETHEUS_BASE_URL)"
+    secret: "$(PROMETHEUS_CLIENT_SECRET)"
+    redirectUris: $(PROMETHEUS_REDIRECT_URIS)
+    webOrigins: $(PROMETHEUS_WEB_ORIGINS)
+    implicitFlowEnabled: true
+    directAccessGrantsEnabled: true
+    publicClient: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "false"
+      exclude.issuer.from.auth.response: "false"
+      backchannel.logout.session.required: "true"
+      client_credentials.use_refresh_token: "false"
+      display.on.consent.screen: "false"
+      oauth2.device.authorization.grant.enabled: "false"
+      backchannel.logout.revoke.offline.tokens: "false"
+      use.refresh.tokens: "true"
+      exclude.session.state.from.auth.response: "false"
+    protocolMappers:
+      - name: "aud-mapper-prometheus"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-audience-mapper"
+        consentRequired: false
+        config:
+          included.client.audience: "prometheus"
+          id.token.claim: "true"
+          access.token.claim: "true"
+    defaultClientScopes:
+      - web-origins
+      - acr
+      - profile
+      - roles
+      - basic
+      - email
+    optionalClientScopes:
+      - "offline_access"
+      - "groups"
+    access: {}
+  - clientId: "argocd"
+    name: "Argo CD"
+    rootUrl: "$(ARGO_CD_ROOT_URL)"
+    adminUrl: "$(ARGO_CD_ADMIN_URL)"
+    baseUrl: "$(ARGO_CD_BASE_URL)"
+    secret: "$(ARGO_CD_CLIENT_SECRET)"
+    redirectUris: $(ARGO_CD_REDIRECT_URIS)
+    webOrigins: $(ARGO_CD_WEB_ORIGINS)
+    publicClient: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "false"
+      oidc.ciba.grant.enabled: "false"
+      exclude.issuer.from.auth.response: "false"
+      backchannel.logout.session.required: "true"
+      client_credentials.use_refresh_token: "false"
+      frontchannel.logout.session.required: "true"
+      display.on.consent.screen: "false"
+      oauth2.device.authorization.grant.enabled: "false"
+      backchannel.logout.revoke.offline.tokens: "false"
+      use.refresh.tokens: "true"
+      exclude.session.state.from.auth.response: "false"
+    defaultClientScopes:
+      - web-origins
+      - acr
+      - profile
+      - roles
+      - basic
+      - email
+    optionalClientScopes:
+      - "offline_access"
+      - "groups"
+    access: {}
+  - clientId: "argo-workflows"
+    name: "Argo Workflows"
+    rootUrl: "$(ARGO_WORKFLOWS_ROOT_URL)"
+    adminUrl: "$(ARGO_WORKFLOWS_ADMIN_URL)"
+    baseUrl: "$(ARGO_WORKFLOWS_BASE_URL)"
+    secret: "$(ARGO_WORKFLOWS_CLIENT_SECRET)"
+    redirectUris: $(ARGO_WORKFLOWS_REDIRECT_URIS)
+    webOrigins: $(ARGO_WORKFLOWS_WEB_ORIGINS)
+    publicClient: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "false"
+      oidc.ciba.grant.enabled: "false"
+      exclude.issuer.from.auth.response: "false"
+      backchannel.logout.session.required: "true"
+      client_credentials.use_refresh_token: "false"
+      frontchannel.logout.session.required: "true"
+      display.on.consent.screen: "false"
+      oauth2.device.authorization.grant.enabled: "false"
+      backchannel.logout.revoke.offline.tokens: "false"
+      use.refresh.tokens: "true"
+      exclude.session.state.from.auth.response: "false"
+    defaultClientScopes:
+      - web-origins
+      - acr
+      - profile
+      - roles
+      - basic
+      - email
+    optionalClientScopes:
+      - "offline_access"
+      - "groups"
+    access: {}
+  - clientId: "alertmanager"
+    name: "Alertmanager"
+    rootUrl: "$(ALERTMANAGER_ROOT_URL)"
+    adminUrl: "$(ALERTMANAGER_ADMIN_URL)"
+    baseUrl: "$(ALERTMANAGER_BASE_URL)"
+    secret: "$(ALERTMANAGER_CLIENT_SECRET)"
+    redirectUris: $(ALERTMANAGER_REDIRECT_URIS)
+    webOrigins: $(ALERTMANAGER_WEB_ORIGINS)
+    implicitFlowEnabled: true
+    directAccessGrantsEnabled: true
+    publicClient: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "false"
+      exclude.issuer.from.auth.response: "false"
+      backchannel.logout.session.required: "true"
+      client_credentials.use_refresh_token: "false"
+      display.on.consent.screen: "false"
+      oauth2.device.authorization.grant.enabled: "false"
+      backchannel.logout.revoke.offline.tokens: "false"
+      use.refresh.tokens: "true"
+      exclude.session.state.from.auth.response: "false"
+    protocolMappers:
+      - name: "aud-mapper-alertmanager"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-audience-mapper"
+        consentRequired: false
+        config:
+          included.client.audience: "alertmanager"
+          id.token.claim: "true"
+          access.token.claim: "true"
+    defaultClientScopes:
+      - web-origins
+      - acr
+      - profile
+      - roles
+      - basic
+      - email
+    optionalClientScopes:
+      - "offline_access"
+      - "groups"
+    access: {}
+clientScopes:
+  - name: "acr"
+    description: "OpenID Connect scope for add acr (authentication context class reference)\
+      \ to the token"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "false"
+      display.on.consent.screen: "false"
+    protocolMappers:
+      - name: "acr loa level"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-acr-mapper"
+        consentRequired: false
+        config:
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+  - name: "organization"
+    description: "Additional claims about the organization a subject belongs to"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "true"
+      consent.screen.text: "${organizationScopeConsentText}"
+      display.on.consent.screen: "true"
+    protocolMappers:
+      - name: "organization"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-organization-membership-mapper"
+        consentRequired: false
+        config:
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "organization"
+          jsonType.label: "String"
+          multivalued: "true"
+  - name: "microprofile-jwt"
+    description: "Microprofile - JWT built-in scope"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "true"
+      display.on.consent.screen: "false"
+    protocolMappers:
+      - name: "groups"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usermodel-realm-role-mapper"
+        consentRequired: false
+        config:
+          introspection.token.claim: "true"
+          multivalued: "true"
+          user.attribute: "foo"
+          id.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "groups"
+          jsonType.label: "String"
+      - name: "upn"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usermodel-attribute-mapper"
+        consentRequired: false
+        config:
+          introspection.token.claim: "true"
+          userinfo.token.claim: "true"
+          user.attribute: "username"
+          id.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "upn"
+          jsonType.label: "String"
+  - name: "basic"
+    description: "OpenID Connect scope for add all basic claims to the token"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "false"
+      display.on.consent.screen: "false"
+    protocolMappers:
+      - name: "sub"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-sub-mapper"
+        consentRequired: false
+        config:
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+      - name: "auth_time"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usersessionmodel-note-mapper"
+        consentRequired: false
+        config:
+          user.session.note: "AUTH_TIME"
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "auth_time"
+          jsonType.label: "long"
+  - name: "service_account"
+    description: "Specific scope for a client enabled for service accounts"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "false"
+      display.on.consent.screen: "false"
+    protocolMappers:
+      - name: "Client ID"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usersessionmodel-note-mapper"
+        consentRequired: false
+        config:
+          user.session.note: "client_id"
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "client_id"
+          jsonType.label: "String"
+      - name: "Client IP Address"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usersessionmodel-note-mapper"
+        consentRequired: false
+        config:
+          user.session.note: "clientAddress"
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "clientAddress"
+          jsonType.label: "String"
+      - name: "Client Host"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usersessionmodel-note-mapper"
+        consentRequired: false
+        config:
+          user.session.note: "clientHost"
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "clientHost"
+          jsonType.label: "String"
+  - name: "groups"
+    description: "When requested, this scope will map a user's group memberships to\
+      \ a claim"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "true"
+      display.on.consent.screen: "false"
+      gui.order: ""
+      consent.screen.text: ""
+    protocolMappers:
+      - name: "groups"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-group-membership-mapper"
+        consentRequired: false
+        config:
+          full.path: "false"
+          id.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "groups"
+          userinfo.token.claim: "true"
+identityProviders:
+  - alias: "google"
+    displayName: ""
+    providerId: "google"
+    enabled: true
+    updateProfileFirstLoginMode: "on"
+    trustEmail: true
+    storeToken: false
+    addReadTokenRoleOnCreate: false
+    authenticateByDefault: false
+    linkOnly: false
+    hideOnLogin: false
+    config:
+      offlineAccess: "false"
+      acceptsPromptNoneForwardFromClient: "false"
+      clientId: "$(GOOGLE_CLIENT_ID)"
+      disableUserInfo: "false"
+      filteredByClaim: "false"
+      syncMode: "LEGACY"
+      clientSecret: "$(GOOGLE_CLIENT_SECRET)"
+      caseSensitiveOriginalUsername: "false"
+      defaultScope: "email openid"
+defaultLocale: ""
+attributes: {}
+keycloakVersion: "26.1.5"

--- a/charts/keycloakx/files/realm/build/master-realm.yaml
+++ b/charts/keycloakx/files/realm/build/master-realm.yaml
@@ -1,0 +1,448 @@
+---
+realm: "master"
+displayName: "Keycloak"
+displayNameHtml: "<div class=\"kc-logo-text\"><span>Keycloak</span></div>"
+accessTokenLifespan: 60
+enabled: true
+roles:
+  realm:
+    - name: "create-realm"
+      description: "${role_create-realm}"
+      composite: false
+      clientRole: false
+    - name: "admin"
+      description: "${role_admin}"
+      composite: true
+      composites:
+        realm:
+          - "create-realm"
+        client:
+          infra-realm:
+            - "view-realm"
+            - "manage-users"
+            - "query-realms"
+            - "view-clients"
+            - "manage-clients"
+            - "query-groups"
+            - "manage-events"
+            - "view-authorization"
+            - "impersonation"
+            - "view-events"
+            - "query-clients"
+            - "manage-realm"
+            - "query-users"
+            - "create-client"
+            - "view-users"
+            - "manage-identity-providers"
+            - "manage-authorization"
+            - "view-identity-providers"
+          master-realm:
+            - "query-clients"
+            - "view-clients"
+            - "view-events"
+            - "manage-clients"
+            - "query-groups"
+            - "query-users"
+            - "create-client"
+            - "manage-events"
+            - "query-realms"
+            - "manage-authorization"
+            - "manage-users"
+            - "view-authorization"
+            - "view-users"
+            - "impersonation"
+            - "view-identity-providers"
+            - "view-realm"
+            - "manage-realm"
+            - "manage-identity-providers"
+      clientRole: false
+  client:
+    infra-realm:
+      - name: "create-client"
+        description: "${role_create-client}"
+        composite: false
+        clientRole: true
+      - name: "manage-identity-providers"
+        description: "${role_manage-identity-providers}"
+        composite: false
+        clientRole: true
+      - name: "view-clients"
+        description: "${role_view-clients}"
+        composite: true
+        composites:
+          client:
+            infra-realm:
+              - "query-clients"
+        clientRole: true
+      - name: "view-users"
+        description: "${role_view-users}"
+        composite: true
+        composites:
+          client:
+            infra-realm:
+              - "query-users"
+              - "query-groups"
+        clientRole: true
+      - name: "manage-clients"
+        description: "${role_manage-clients}"
+        composite: false
+        clientRole: true
+      - name: "view-events"
+        description: "${role_view-events}"
+        composite: false
+        clientRole: true
+      - name: "view-realm"
+        description: "${role_view-realm}"
+        composite: false
+        clientRole: true
+      - name: "manage-authorization"
+        description: "${role_manage-authorization}"
+        composite: false
+        clientRole: true
+      - name: "query-groups"
+        description: "${role_query-groups}"
+        composite: false
+        clientRole: true
+      - name: "manage-users"
+        description: "${role_manage-users}"
+        composite: false
+        clientRole: true
+      - name: "view-identity-providers"
+        description: "${role_view-identity-providers}"
+        composite: false
+        clientRole: true
+      - name: "query-realms"
+        description: "${role_query-realms}"
+        composite: false
+        clientRole: true
+      - name: "query-clients"
+        description: "${role_query-clients}"
+        composite: false
+        clientRole: true
+      - name: "manage-events"
+        description: "${role_manage-events}"
+        composite: false
+        clientRole: true
+      - name: "impersonation"
+        description: "${role_impersonation}"
+        composite: false
+        clientRole: true
+      - name: "view-authorization"
+        description: "${role_view-authorization}"
+        composite: false
+        clientRole: true
+      - name: "manage-realm"
+        description: "${role_manage-realm}"
+        composite: false
+        clientRole: true
+      - name: "query-users"
+        description: "${role_query-users}"
+        composite: false
+        clientRole: true
+    master-realm:
+      - name: "manage-events"
+        description: "${role_manage-events}"
+        composite: false
+        clientRole: true
+        containerId: "8bb6c065-c25a-40c9-8d6c-97742283a54b"
+      - name: "query-groups"
+        description: "${role_query-groups}"
+        composite: false
+        clientRole: true
+      - name: "query-realms"
+        description: "${role_query-realms}"
+        composite: false
+        clientRole: true
+      - name: "impersonation"
+        description: "${role_impersonation}"
+        composite: false
+        clientRole: true
+      - name: "view-users"
+        description: "${role_view-users}"
+        composite: true
+        composites:
+          client:
+            master-realm:
+              - "query-groups"
+              - "query-users"
+        clientRole: true
+      - name: "view-identity-providers"
+        description: "${role_view-identity-providers}"
+        composite: false
+        clientRole: true
+      - name: "manage-authorization"
+        description: "${role_manage-authorization}"
+        composite: false
+        clientRole: true
+      - name: "query-users"
+        description: "${role_query-users}"
+        composite: false
+        clientRole: true
+      - name: "create-client"
+        description: "${role_create-client}"
+        composite: false
+        clientRole: true
+      - name: "manage-users"
+        description: "${role_manage-users}"
+        composite: false
+        clientRole: true
+      - name: "view-authorization"
+        description: "${role_view-authorization}"
+        composite: false
+        clientRole: true
+      - name: "manage-realm"
+        description: "${role_manage-realm}"
+        composite: false
+        clientRole: true
+      - name: "query-clients"
+        description: "${role_query-clients}"
+        composite: false
+        clientRole: true
+      - name: "view-realm"
+        description: "${role_view-realm}"
+        composite: false
+        clientRole: true
+      - name: "view-clients"
+        description: "${role_view-clients}"
+        composite: true
+        composites:
+          client:
+            master-realm:
+              - "query-clients"
+        clientRole: true
+      - name: "manage-clients"
+        description: "${role_manage-clients}"
+        composite: false
+        clientRole: true
+      - name: "manage-identity-providers"
+        description: "${role_manage-identity-providers}"
+        composite: false
+        clientRole: true
+      - name: "view-events"
+        description: "${role_view-events}"
+        composite: false
+        clientRole: true
+groups:
+  - name: "CHORUS-admin"
+    path: "/CHORUS-admin"
+    subGroups: []
+    realmRoles:
+      - "admin"
+webAuthnPolicySignatureAlgorithms:
+  - "ES256"
+  - "RS256"
+webAuthnPolicyPasswordlessSignatureAlgorithms:
+  - "ES256"
+  - "RS256"
+clients:
+  - clientId: "admin-cli"
+    name: "${client_admin-cli}"
+    redirectUris: []
+    webOrigins: []
+    standardFlowEnabled: false
+    directAccessGrantsEnabled: true
+    publicClient: true
+    frontchannelLogout: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "false"
+      client.use.lightweight.access.token.enabled: "true"
+    nodeReRegistrationTimeout: 0
+    access: {}
+  - clientId: "broker"
+    name: "${client_broker}"
+    redirectUris: []
+    webOrigins: []
+    bearerOnly: true
+    publicClient: false
+    frontchannelLogout: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "true"
+    fullScopeAllowed: false
+    nodeReRegistrationTimeout: 0
+    access: {}
+  - clientId: "infra-realm"
+    name: "infra Realm"
+    redirectUris: []
+    webOrigins: []
+    bearerOnly: true
+    publicClient: false
+    frontchannelLogout: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "true"
+    fullScopeAllowed: false
+    nodeReRegistrationTimeout: 0
+    defaultClientScopes: []
+    optionalClientScopes: []
+    access: {}
+  - clientId: "master-realm"
+    name: "master Realm"
+    redirectUris: []
+    webOrigins: []
+    bearerOnly: true
+    publicClient: false
+    frontchannelLogout: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "true"
+    fullScopeAllowed: false
+    nodeReRegistrationTimeout: 0
+    access: {}
+clientScopes:
+  - name: "acr"
+    description: "OpenID Connect scope for add acr (authentication context class reference)\
+      \ to the token"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "false"
+      display.on.consent.screen: "false"
+    protocolMappers:
+      - name: "acr loa level"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-acr-mapper"
+        consentRequired: false
+        config:
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+  - name: "organization"
+    description: "Additional claims about the organization a subject belongs to"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "true"
+      consent.screen.text: "${organizationScopeConsentText}"
+      display.on.consent.screen: "true"
+    protocolMappers:
+      - name: "organization"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-organization-membership-mapper"
+        consentRequired: false
+        config:
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "organization"
+          jsonType.label: "String"
+          multivalued: "true"
+  - name: "microprofile-jwt"
+    description: "Microprofile - JWT built-in scope"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "true"
+      display.on.consent.screen: "false"
+    protocolMappers:
+      - name: "groups"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usermodel-realm-role-mapper"
+        consentRequired: false
+        config:
+          introspection.token.claim: "true"
+          multivalued: "true"
+          user.attribute: "foo"
+          id.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "groups"
+          jsonType.label: "String"
+      - name: "upn"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usermodel-attribute-mapper"
+        consentRequired: false
+        config:
+          introspection.token.claim: "true"
+          userinfo.token.claim: "true"
+          user.attribute: "username"
+          id.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "upn"
+          jsonType.label: "String"
+  - name: "basic"
+    description: "OpenID Connect scope for add all basic claims to the token"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "false"
+      display.on.consent.screen: "false"
+    protocolMappers:
+      - name: "auth_time"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usersessionmodel-note-mapper"
+        consentRequired: false
+        config:
+          user.session.note: "AUTH_TIME"
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "auth_time"
+          jsonType.label: "long"
+      - name: "sub"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-sub-mapper"
+        consentRequired: false
+        config:
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+  - name: "service_account"
+    description: "Specific scope for a client enabled for service accounts"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "false"
+      display.on.consent.screen: "false"
+    protocolMappers:
+      - name: "Client IP Address"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usersessionmodel-note-mapper"
+        consentRequired: false
+        config:
+          user.session.note: "clientAddress"
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "clientAddress"
+          jsonType.label: "String"
+      - name: "Client ID"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usersessionmodel-note-mapper"
+        consentRequired: false
+        config:
+          user.session.note: "client_id"
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "client_id"
+          jsonType.label: "String"
+      - name: "Client Host"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usersessionmodel-note-mapper"
+        consentRequired: false
+        config:
+          user.session.note: "clientHost"
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "clientHost"
+          jsonType.label: "String"
+identityProviders:
+  - alias: "google"
+    displayName: ""
+    providerId: "google"
+    enabled: true
+    updateProfileFirstLoginMode: "on"
+    trustEmail: false
+    storeToken: false
+    addReadTokenRoleOnCreate: false
+    authenticateByDefault: false
+    linkOnly: false
+    hideOnLogin: false
+    config:
+      offlineAccess: "true"
+      acceptsPromptNoneForwardFromClient: "false"
+      clientId: "$(GOOGLE_CLIENT_ID)"
+      disableUserInfo: "true"
+      filteredByClaim: "false"
+      syncMode: "FORCE"
+      clientSecret: "$(GOOGLE_CLIENT_SECRET)"
+      caseSensitiveOriginalUsername: "false"
+      defaultScope: "email openid"
+attributes: {}
+keycloakVersion: "26.1.5"

--- a/charts/keycloakx/files/realm/remote/chorus-realm.yaml
+++ b/charts/keycloakx/files/realm/remote/chorus-realm.yaml
@@ -1,0 +1,247 @@
+---
+realm: "chorus"
+displayName: ""
+displayNameHtml: ""
+revokeRefreshToken: true
+enabled: true
+registrationAllowed: false
+passwordPolicy: "length(8) and specialChars(1) and upperCase(1) and lowerCase(1) and\
+  \ digits(1) and notUsername and notEmail and notContainsUsername"
+webAuthnPolicySignatureAlgorithms:
+  - "ES256"
+  - "RS256"
+webAuthnPolicyPasswordlessSignatureAlgorithms:
+  - "ES256"
+  - "RS256"
+clients:
+  - clientId: "admin-cli"
+    name: "${client_admin-cli}"
+    redirectUris: []
+    webOrigins: []
+    standardFlowEnabled: false
+    directAccessGrantsEnabled: true
+    publicClient: true
+    frontchannelLogout: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "false"
+      client.use.lightweight.access.token.enabled: "true"
+    nodeReRegistrationTimeout: 0
+    access: {}
+  - clientId: "broker"
+    name: "${client_broker}"
+    redirectUris: []
+    webOrigins: []
+    bearerOnly: true
+    publicClient: false
+    frontchannelLogout: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "true"
+    fullScopeAllowed: false
+    nodeReRegistrationTimeout: 0
+    access: {}
+  - clientId: "realm-management"
+    name: "${client_realm-management}"
+    redirectUris: []
+    webOrigins: []
+    bearerOnly: true
+    publicClient: false
+    frontchannelLogout: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "true"
+    fullScopeAllowed: false
+    nodeReRegistrationTimeout: 0
+    access: {}
+  - clientId: "chorus"
+    name: "Chorus"
+    rootUrl: "$(CHORUS_ROOT_URL)"
+    adminUrl: "$(CHORUS_ADMIN_URL)"
+    baseUrl: "$(CHORUS_BASE_URL)"
+    secret: "$(CHORUS_CLIENT_SECRET)"
+    redirectUris: $(CHORUS_REDIRECT_URIS)
+    webOrigins: $(CHORUS_WEB_ORIGINS)
+    implicitFlowEnabled: true
+    directAccessGrantsEnabled: true
+    publicClient: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "false"
+      oidc.ciba.grant.enabled: "false"
+      exclude.issuer.from.auth.response: "false"
+      backchannel.logout.session.required: "true"
+      client_credentials.use_refresh_token: "false"
+      frontchannel.logout.session.required: "true"
+      post.logout.redirect.uris: "+"
+      display.on.consent.screen: "false"
+      oauth2.device.authorization.grant.enabled: "true"
+      backchannel.logout.revoke.offline.tokens: "false"
+      use.refresh.tokens: "true"
+      exclude.session.state.from.auth.response: "false"
+    defaultClientScopes:
+      - web-origins
+      - acr
+      - profile
+      - roles
+      - basic
+      - email
+    optionalClientScopes:
+      - "offline_access"
+    access: {}
+clientScopes:
+  - name: "acr"
+    description: "OpenID Connect scope for add acr (authentication context class reference)\
+      \ to the token"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "false"
+      display.on.consent.screen: "false"
+    protocolMappers:
+      - name: "acr loa level"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-acr-mapper"
+        consentRequired: false
+        config:
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+  - name: "organization"
+    description: "Additional claims about the organization a subject belongs to"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "true"
+      consent.screen.text: "${organizationScopeConsentText}"
+      display.on.consent.screen: "true"
+    protocolMappers:
+      - name: "organization"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-organization-membership-mapper"
+        consentRequired: false
+        config:
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "organization"
+          jsonType.label: "String"
+          multivalued: "true"
+  - name: "microprofile-jwt"
+    description: "Microprofile - JWT built-in scope"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "true"
+      display.on.consent.screen: "false"
+    protocolMappers:
+      - name: "groups"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usermodel-realm-role-mapper"
+        consentRequired: false
+        config:
+          introspection.token.claim: "true"
+          multivalued: "true"
+          user.attribute: "foo"
+          id.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "groups"
+          jsonType.label: "String"
+      - name: "upn"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usermodel-attribute-mapper"
+        consentRequired: false
+        config:
+          introspection.token.claim: "true"
+          userinfo.token.claim: "true"
+          user.attribute: "username"
+          id.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "upn"
+          jsonType.label: "String"
+  - name: "basic"
+    description: "OpenID Connect scope for add all basic claims to the token"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "false"
+      display.on.consent.screen: "false"
+    protocolMappers:
+      - name: "auth_time"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usersessionmodel-note-mapper"
+        consentRequired: false
+        config:
+          user.session.note: "AUTH_TIME"
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "auth_time"
+          jsonType.label: "long"
+      - name: "sub"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-sub-mapper"
+        consentRequired: false
+        config:
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+  - name: "service_account"
+    description: "Specific scope for a client enabled for service accounts"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "false"
+      display.on.consent.screen: "false"
+    protocolMappers:
+      - name: "Client IP Address"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usersessionmodel-note-mapper"
+        consentRequired: false
+        config:
+          user.session.note: "clientAddress"
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "clientAddress"
+          jsonType.label: "String"
+      - name: "Client Host"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usersessionmodel-note-mapper"
+        consentRequired: false
+        config:
+          user.session.note: "clientHost"
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "clientHost"
+          jsonType.label: "String"
+      - name: "Client ID"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usersessionmodel-note-mapper"
+        consentRequired: false
+        config:
+          user.session.note: "client_id"
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "client_id"
+          jsonType.label: "String"
+  - name: "groups"
+    description: ""
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "false"
+      display.on.consent.screen: "true"
+      gui.order: ""
+      consent.screen.text: ""
+    protocolMappers:
+      - name: "groups"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-group-membership-mapper"
+        consentRequired: false
+        config:
+          full.path: "false"
+          introspection.token.claim: "true"
+          userinfo.token.claim: "true"
+          id.token.claim: "true"
+          lightweight.claim: "false"
+          access.token.claim: "true"
+          claim.name: "groups"
+defaultLocale: ""
+attributes: {}
+keycloakVersion: "26.1.5"

--- a/charts/keycloakx/files/realm/remote/infra-realm.yaml
+++ b/charts/keycloakx/files/realm/remote/infra-realm.yaml
@@ -1,0 +1,500 @@
+---
+realm: "infra"
+displayName: ""
+displayNameHtml: ""
+revokeRefreshToken: true
+enabled: true
+registrationAllowed: false
+roles:
+  client:
+    grafana:
+      - name: editor
+        description: ""
+        composite: false
+        clientRole: true
+        attributes: {}
+      - name: admin
+        description: ""
+        composite: false
+        clientRole: true
+        attributes: {}
+groups:
+  - name: "HarborAdmins"
+    path: "/HarborAdmins"
+    subGroups: []
+  - name: "Grafana"
+    path: "/Grafana"
+    subGroups:
+      - name: "Editors"
+        path: "/Grafana/Editors"
+        subGroups:
+          - name: "Administrators"
+            path: "/Grafana/Editors/Administrators"
+            subGroups: []
+            realmRoles: []
+            clientRoles:
+              grafana:
+                - admin
+        realmRoles: []
+        clientRoles:
+          grafana:
+            - editor
+passwordPolicy: "length(8) and specialChars(1) and upperCase(1) and lowerCase(1) and\
+  \ digits(1) and notUsername and notEmail and notContainsUsername"
+webAuthnPolicySignatureAlgorithms:
+  - "ES256"
+  - "RS256"
+webAuthnPolicyPasswordlessSignatureAlgorithms:
+  - "ES256"
+  - "RS256"
+clients:
+  - clientId: "admin-cli"
+    name: "${client_admin-cli}"
+    redirectUris: []
+    webOrigins: []
+    standardFlowEnabled: false
+    directAccessGrantsEnabled: true
+    publicClient: true
+    frontchannelLogout: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "false"
+      client.use.lightweight.access.token.enabled: "true"
+    nodeReRegistrationTimeout: 0
+    access: {}
+  - clientId: "broker"
+    name: "${client_broker}"
+    redirectUris: []
+    webOrigins: []
+    bearerOnly: true
+    publicClient: false
+    frontchannelLogout: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "true"
+    fullScopeAllowed: false
+    nodeReRegistrationTimeout: 0
+    access: {}
+  - clientId: "realm-management"
+    name: "${client_realm-management}"
+    redirectUris: []
+    webOrigins: []
+    bearerOnly: true
+    publicClient: false
+    frontchannelLogout: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "true"
+    fullScopeAllowed: false
+    nodeReRegistrationTimeout: 0
+    access: {}
+  - clientId: "grafana"
+    name: "Grafana"
+    rootUrl: "$(GRAFANA_ROOT_URL)"
+    adminUrl: "$(GRAFANA_ADMIN_URL)"
+    baseUrl: "$(GRAFANA_BASE_URL)"
+    secret: "$(GRAFANA_CLIENT_SECRET)"
+    redirectUris: $(GRAFANA_REDIRECT_URIS)
+    webOrigins: $(GRAFANA_WEB_ORIGINS)
+    implicitFlowEnabled: true
+    directAccessGrantsEnabled: true
+    publicClient: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "false"
+      exclude.issuer.from.auth.response: "false"
+      backchannel.logout.session.required: "true"
+      client_credentials.use_refresh_token: "false"
+      display.on.consent.screen: "false"
+      oauth2.device.authorization.grant.enabled: "false"
+      backchannel.logout.revoke.offline.tokens: "false"
+      use.refresh.tokens: "true"
+      exclude.session.state.from.auth.response: "false"
+    protocolMappers:
+      - name: client roles
+        protocol: openid-connect
+        protocolMapper: oidc-usermodel-client-role-mapper
+        consentRequired: false
+        config:
+          introspection.token.claim: "true"
+          multivalued: "true"
+          userinfo.token.claim: "false"
+          user.attribute: foo
+          id.token.claim: "true"
+          lightweight.claim: "false"
+          access.token.claim: "true"
+          claim.name: roles
+          jsonType.label: String
+    defaultClientScopes:
+      - web-origins
+      - acr
+      - profile
+      - roles
+      - basic
+      - email
+    optionalClientScopes:
+      - "offline_access"
+      - "groups"
+    access: {}
+  - clientId: "harbor"
+    name: "Harbor"
+    rootUrl: "$(HARBOR_ROOT_URL)"
+    adminUrl: "$(HARBOR_ADMIN_URL)"
+    baseUrl: "$(HARBOR_BASE_URL)"
+    secret: "$(HARBOR_CLIENT_SECRET)"
+    redirectUris: $(HARBOR_REDIRECT_URIS)
+    webOrigins: $(HARBOR_WEB_ORIGINS)
+    implicitFlowEnabled: true
+    directAccessGrantsEnabled: true
+    publicClient: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "false"
+      exclude.issuer.from.auth.response: "false"
+      backchannel.logout.session.required: "true"
+      client_credentials.use_refresh_token: "false"
+      display.on.consent.screen: "false"
+      oauth2.device.authorization.grant.enabled: "false"
+      backchannel.logout.revoke.offline.tokens: "false"
+      use.refresh.tokens: "true"
+      exclude.session.state.from.auth.response: "false"
+    defaultClientScopes:
+      - web-origins
+      - acr
+      - profile
+      - roles
+      - basic
+      - email
+    optionalClientScopes:
+      - "offline_access"
+      - "groups"
+    access: {}
+  - clientId: "juicefs-dashboard"
+    name: "JuiceFS Dashboard"
+    rootUrl: "$(JUICEFS_DASHBOARD_ROOT_URL)"
+    adminUrl: "$(JUICEFS_DASHBOARD_ADMIN_URL)"
+    baseUrl: "$(JUICEFS_DASHBOARD_BASE_URL)"
+    secret: "$(JUICEFS_DASHBOARD_CLIENT_SECRET)"
+    redirectUris: $(JUICEFS_DASHBOARD_REDIRECT_URIS)
+    webOrigins: $(JUICEFS_DASHBOARD_WEB_ORIGINS)
+    implicitFlowEnabled: true
+    directAccessGrantsEnabled: true
+    publicClient: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "false"
+      exclude.issuer.from.auth.response: "false"
+      backchannel.logout.session.required: "true"
+      client_credentials.use_refresh_token: "false"
+      display.on.consent.screen: "false"
+      oauth2.device.authorization.grant.enabled: "false"
+      backchannel.logout.revoke.offline.tokens: "false"
+      use.refresh.tokens: "true"
+      exclude.session.state.from.auth.response: "false"
+    defaultClientScopes:
+      - web-origins
+      - acr
+      - profile
+      - roles
+      - basic
+      - email
+    optionalClientScopes:
+      - "offline_access"
+      - "groups"
+    access: {}
+  - clientId: "prometheus"
+    name: "Prometheus"
+    rootUrl: "$(PROMETHEUS_ROOT_URL)"
+    adminUrl: "$(PROMETHEUS_ADMIN_URL)"
+    baseUrl: "$(PROMETHEUS_BASE_URL)"
+    secret: "$(PROMETHEUS_CLIENT_SECRET)"
+    redirectUris: $(PROMETHEUS_REDIRECT_URIS)
+    webOrigins: $(PROMETHEUS_WEB_ORIGINS)
+    implicitFlowEnabled: true
+    directAccessGrantsEnabled: true
+    publicClient: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "false"
+      exclude.issuer.from.auth.response: "false"
+      backchannel.logout.session.required: "true"
+      client_credentials.use_refresh_token: "false"
+      display.on.consent.screen: "false"
+      oauth2.device.authorization.grant.enabled: "false"
+      backchannel.logout.revoke.offline.tokens: "false"
+      use.refresh.tokens: "true"
+      exclude.session.state.from.auth.response: "false"
+    protocolMappers:
+      - name: "aud-mapper-prometheus"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-audience-mapper"
+        consentRequired: false
+        config:
+          included.client.audience: "prometheus"
+          id.token.claim: "true"
+          access.token.claim: "true"
+    defaultClientScopes:
+      - web-origins
+      - acr
+      - profile
+      - roles
+      - basic
+      - email
+    optionalClientScopes:
+      - "offline_access"
+      - "groups"
+    access: {}
+  - clientId: "matomo"
+    name: "Matomo"
+    rootUrl: "$(MATOMO_ROOT_URL)"
+    adminUrl: "$(MATOMO_ADMIN_URL)"
+    baseUrl: "$(MATOMO_BASE_URL)"
+    secret: "$(MATOMO_CLIENT_SECRET)"
+    redirectUris: $(MATOMO_REDIRECT_URIS)
+    webOrigins: $(MATOMO_WEB_ORIGINS)
+    publicClient: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "false"
+      oidc.ciba.grant.enabled: "false"
+      exclude.issuer.from.auth.response: "false"
+      backchannel.logout.session.required: "true"
+      client_credentials.use_refresh_token: "false"
+      frontchannel.logout.session.required: "true"
+      display.on.consent.screen: "false"
+      oauth2.device.authorization.grant.enabled: "false"
+      backchannel.logout.revoke.offline.tokens: "false"
+      use.refresh.tokens: "true"
+      exclude.session.state.from.auth.response: "false"
+    defaultClientScopes:
+      - web-origins
+      - acr
+      - profile
+      - roles
+      - basic
+      - email
+    optionalClientScopes:
+      - "address"
+      - "phone"
+      - "offline_access"
+      - "microprofile-jwt"
+    access: {}
+  - clientId: "alertmanager"
+    name: "Alertmanager"
+    rootUrl: "$(ALERTMANAGER_ROOT_URL)"
+    adminUrl: "$(ALERTMANAGER_ADMIN_URL)"
+    baseUrl: "$(ALERTMANAGER_BASE_URL)"
+    secret: "$(ALERTMANAGER_CLIENT_SECRET)"
+    redirectUris: $(ALERTMANAGER_REDIRECT_URIS)
+    webOrigins: $(ALERTMANAGER_WEB_ORIGINS)
+    implicitFlowEnabled: true
+    directAccessGrantsEnabled: true
+    publicClient: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "false"
+      exclude.issuer.from.auth.response: "false"
+      backchannel.logout.session.required: "true"
+      client_credentials.use_refresh_token: "false"
+      display.on.consent.screen: "false"
+      oauth2.device.authorization.grant.enabled: "false"
+      backchannel.logout.revoke.offline.tokens: "false"
+      use.refresh.tokens: "true"
+      exclude.session.state.from.auth.response: "false"
+    protocolMappers:
+      - name: "aud-mapper-alertmanager"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-audience-mapper"
+        consentRequired: false
+        config:
+          included.client.audience: "alertmanager"
+          id.token.claim: "true"
+          access.token.claim: "true"
+    defaultClientScopes:
+      - web-origins
+      - acr
+      - profile
+      - roles
+      - basic
+      - email
+    optionalClientScopes:
+      - "offline_access"
+      - "groups"
+    access: {}
+clientScopes:
+  - name: "acr"
+    description: "OpenID Connect scope for add acr (authentication context class reference)\
+      \ to the token"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "false"
+      display.on.consent.screen: "false"
+    protocolMappers:
+      - name: "acr loa level"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-acr-mapper"
+        consentRequired: false
+        config:
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+  - name: "organization"
+    description: "Additional claims about the organization a subject belongs to"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "true"
+      consent.screen.text: "${organizationScopeConsentText}"
+      display.on.consent.screen: "true"
+    protocolMappers:
+      - name: "organization"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-organization-membership-mapper"
+        consentRequired: false
+        config:
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "organization"
+          jsonType.label: "String"
+          multivalued: "true"
+  - name: "microprofile-jwt"
+    description: "Microprofile - JWT built-in scope"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "true"
+      display.on.consent.screen: "false"
+    protocolMappers:
+      - name: "groups"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usermodel-realm-role-mapper"
+        consentRequired: false
+        config:
+          introspection.token.claim: "true"
+          multivalued: "true"
+          user.attribute: "foo"
+          id.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "groups"
+          jsonType.label: "String"
+      - name: "upn"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usermodel-attribute-mapper"
+        consentRequired: false
+        config:
+          introspection.token.claim: "true"
+          userinfo.token.claim: "true"
+          user.attribute: "username"
+          id.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "upn"
+          jsonType.label: "String"
+  - name: "basic"
+    description: "OpenID Connect scope for add all basic claims to the token"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "false"
+      display.on.consent.screen: "false"
+    protocolMappers:
+      - name: "sub"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-sub-mapper"
+        consentRequired: false
+        config:
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+      - name: "auth_time"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usersessionmodel-note-mapper"
+        consentRequired: false
+        config:
+          user.session.note: "AUTH_TIME"
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "auth_time"
+          jsonType.label: "long"
+  - name: "service_account"
+    description: "Specific scope for a client enabled for service accounts"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "false"
+      display.on.consent.screen: "false"
+    protocolMappers:
+      - name: "Client ID"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usersessionmodel-note-mapper"
+        consentRequired: false
+        config:
+          user.session.note: "client_id"
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "client_id"
+          jsonType.label: "String"
+      - name: "Client IP Address"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usersessionmodel-note-mapper"
+        consentRequired: false
+        config:
+          user.session.note: "clientAddress"
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "clientAddress"
+          jsonType.label: "String"
+      - name: "Client Host"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usersessionmodel-note-mapper"
+        consentRequired: false
+        config:
+          user.session.note: "clientHost"
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "clientHost"
+          jsonType.label: "String"
+  - name: "groups"
+    description: "When requested, this scope will map a user's group memberships to\
+      \ a claim"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "true"
+      display.on.consent.screen: "false"
+      gui.order: ""
+      consent.screen.text: ""
+    protocolMappers:
+      - name: "groups"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-group-membership-mapper"
+        consentRequired: false
+        config:
+          full.path: "false"
+          id.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "groups"
+          userinfo.token.claim: "true"
+identityProviders:
+  - alias: "google"
+    displayName: ""
+    providerId: "google"
+    enabled: true
+    updateProfileFirstLoginMode: "on"
+    trustEmail: true
+    storeToken: false
+    addReadTokenRoleOnCreate: false
+    authenticateByDefault: false
+    linkOnly: false
+    hideOnLogin: false
+    config:
+      offlineAccess: "false"
+      acceptsPromptNoneForwardFromClient: "false"
+      clientId: "$(GOOGLE_CLIENT_ID)"
+      disableUserInfo: "false"
+      filteredByClaim: "false"
+      syncMode: "LEGACY"
+      clientSecret: "$(GOOGLE_CLIENT_SECRET)"
+      caseSensitiveOriginalUsername: "false"
+      defaultScope: "email openid"
+defaultLocale: ""
+attributes: {}
+keycloakVersion: "26.1.5"

--- a/charts/keycloakx/files/realm/remote/master-realm.yaml
+++ b/charts/keycloakx/files/realm/remote/master-realm.yaml
@@ -1,0 +1,564 @@
+---
+realm: "master"
+displayName: "Keycloak"
+displayNameHtml: "<div class=\"kc-logo-text\"><span>Keycloak</span></div>"
+accessTokenLifespan: 60
+enabled: true
+roles:
+  realm:
+    - name: "create-realm"
+      description: "${role_create-realm}"
+      composite: false
+      clientRole: false
+    - name: "admin"
+      description: "${role_admin}"
+      composite: true
+      composites:
+        realm:
+          - "create-realm"
+        client:
+          infra-realm:
+            - "view-realm"
+            - "manage-users"
+            - "query-realms"
+            - "view-clients"
+            - "manage-clients"
+            - "query-groups"
+            - "manage-events"
+            - "view-authorization"
+            - "impersonation"
+            - "view-events"
+            - "query-clients"
+            - "manage-realm"
+            - "query-users"
+            - "create-client"
+            - "view-users"
+            - "manage-identity-providers"
+            - "manage-authorization"
+            - "view-identity-providers"
+          chorus-realm:
+            - "manage-authorization"
+            - "manage-realm"
+            - "view-identity-providers"
+            - "manage-users"
+            - "query-groups"
+            - "view-clients"
+            - "view-authorization"
+            - "manage-events"
+            - "create-client"
+            - "view-realm"
+            - "query-clients"
+            - "impersonation"
+            - "manage-clients"
+            - "manage-identity-providers"
+            - "query-users"
+            - "query-realms"
+            - "view-events"
+            - "view-users"
+          master-realm:
+            - "query-clients"
+            - "view-clients"
+            - "view-events"
+            - "manage-clients"
+            - "query-groups"
+            - "query-users"
+            - "create-client"
+            - "manage-events"
+            - "query-realms"
+            - "manage-authorization"
+            - "manage-users"
+            - "view-authorization"
+            - "view-users"
+            - "impersonation"
+            - "view-identity-providers"
+            - "view-realm"
+            - "manage-realm"
+            - "manage-identity-providers"
+      clientRole: false
+  client:
+    infra-realm:
+      - name: "create-client"
+        description: "${role_create-client}"
+        composite: false
+        clientRole: true
+      - name: "manage-identity-providers"
+        description: "${role_manage-identity-providers}"
+        composite: false
+        clientRole: true
+      - name: "view-clients"
+        description: "${role_view-clients}"
+        composite: true
+        composites:
+          client:
+            infra-realm:
+              - "query-clients"
+        clientRole: true
+      - name: "view-users"
+        description: "${role_view-users}"
+        composite: true
+        composites:
+          client:
+            infra-realm:
+              - "query-users"
+              - "query-groups"
+        clientRole: true
+      - name: "manage-clients"
+        description: "${role_manage-clients}"
+        composite: false
+        clientRole: true
+      - name: "view-events"
+        description: "${role_view-events}"
+        composite: false
+        clientRole: true
+      - name: "view-realm"
+        description: "${role_view-realm}"
+        composite: false
+        clientRole: true
+      - name: "manage-authorization"
+        description: "${role_manage-authorization}"
+        composite: false
+        clientRole: true
+      - name: "query-groups"
+        description: "${role_query-groups}"
+        composite: false
+        clientRole: true
+      - name: "manage-users"
+        description: "${role_manage-users}"
+        composite: false
+        clientRole: true
+      - name: "view-identity-providers"
+        description: "${role_view-identity-providers}"
+        composite: false
+        clientRole: true
+      - name: "query-realms"
+        description: "${role_query-realms}"
+        composite: false
+        clientRole: true
+      - name: "query-clients"
+        description: "${role_query-clients}"
+        composite: false
+        clientRole: true
+      - name: "manage-events"
+        description: "${role_manage-events}"
+        composite: false
+        clientRole: true
+      - name: "impersonation"
+        description: "${role_impersonation}"
+        composite: false
+        clientRole: true
+      - name: "view-authorization"
+        description: "${role_view-authorization}"
+        composite: false
+        clientRole: true
+      - name: "manage-realm"
+        description: "${role_manage-realm}"
+        composite: false
+        clientRole: true
+      - name: "query-users"
+        description: "${role_query-users}"
+        composite: false
+        clientRole: true
+    chorus-realm:
+      - name: "manage-authorization"
+        description: "${role_manage-authorization}"
+        composite: false
+        clientRole: true
+      - name: "manage-realm"
+        description: "${role_manage-realm}"
+        composite: false
+        clientRole: true
+      - name: "impersonation"
+        description: "${role_impersonation}"
+        composite: false
+        clientRole: true
+      - name: "query-clients"
+        description: "${role_query-clients}"
+        composite: false
+        clientRole: true
+      - name: "query-realms"
+        description: "${role_query-realms}"
+        composite: false
+        clientRole: true
+      - name: "manage-clients"
+        description: "${role_manage-clients}"
+        composite: false
+        clientRole: true
+      - name: "view-identity-providers"
+        description: "${role_view-identity-providers}"
+        composite: false
+        clientRole: true
+      - name: "manage-users"
+        description: "${role_manage-users}"
+        composite: false
+        clientRole: true
+      - name: "query-groups"
+        description: "${role_query-groups}"
+        composite: false
+        clientRole: true
+      - name: "manage-identity-providers"
+        description: "${role_manage-identity-providers}"
+        composite: false
+        clientRole: true
+      - name: "view-clients"
+        description: "${role_view-clients}"
+        composite: true
+        composites:
+          client:
+            chorus-realm:
+              - "query-clients"
+        clientRole: true
+      - name: "create-client"
+        description: "${role_create-client}"
+        composite: false
+        clientRole: true
+      - name: "view-realm"
+        description: "${role_view-realm}"
+        composite: false
+        clientRole: true
+      - name: "view-events"
+        description: "${role_view-events}"
+        composite: false
+        clientRole: true
+      - name: "view-users"
+        description: "${role_view-users}"
+        composite: true
+        composites:
+          client:
+            chorus-realm:
+              - "query-groups"
+              - "query-users"
+        clientRole: true
+      - name: "view-authorization"
+        description: "${role_view-authorization}"
+        composite: false
+        clientRole: true
+      - name: "manage-events"
+        description: "${role_manage-events}"
+        composite: false
+        clientRole: true
+      - name: "query-users"
+        description: "${role_query-users}"
+        composite: false
+        clientRole: true
+    master-realm:
+      - name: "manage-events"
+        description: "${role_manage-events}"
+        composite: false
+        clientRole: true
+        containerId: "8bb6c065-c25a-40c9-8d6c-97742283a54b"
+      - name: "query-groups"
+        description: "${role_query-groups}"
+        composite: false
+        clientRole: true
+      - name: "query-realms"
+        description: "${role_query-realms}"
+        composite: false
+        clientRole: true
+      - name: "impersonation"
+        description: "${role_impersonation}"
+        composite: false
+        clientRole: true
+      - name: "view-users"
+        description: "${role_view-users}"
+        composite: true
+        composites:
+          client:
+            master-realm:
+              - "query-groups"
+              - "query-users"
+        clientRole: true
+      - name: "view-identity-providers"
+        description: "${role_view-identity-providers}"
+        composite: false
+        clientRole: true
+      - name: "manage-authorization"
+        description: "${role_manage-authorization}"
+        composite: false
+        clientRole: true
+      - name: "query-users"
+        description: "${role_query-users}"
+        composite: false
+        clientRole: true
+      - name: "create-client"
+        description: "${role_create-client}"
+        composite: false
+        clientRole: true
+      - name: "manage-users"
+        description: "${role_manage-users}"
+        composite: false
+        clientRole: true
+      - name: "view-authorization"
+        description: "${role_view-authorization}"
+        composite: false
+        clientRole: true
+      - name: "manage-realm"
+        description: "${role_manage-realm}"
+        composite: false
+        clientRole: true
+      - name: "query-clients"
+        description: "${role_query-clients}"
+        composite: false
+        clientRole: true
+      - name: "view-realm"
+        description: "${role_view-realm}"
+        composite: false
+        clientRole: true
+      - name: "view-clients"
+        description: "${role_view-clients}"
+        composite: true
+        composites:
+          client:
+            master-realm:
+              - "query-clients"
+        clientRole: true
+      - name: "manage-clients"
+        description: "${role_manage-clients}"
+        composite: false
+        clientRole: true
+      - name: "manage-identity-providers"
+        description: "${role_manage-identity-providers}"
+        composite: false
+        clientRole: true
+      - name: "view-events"
+        description: "${role_view-events}"
+        composite: false
+        clientRole: true
+groups:
+  - name: "CHORUS-admin"
+    path: "/CHORUS-admin"
+    subGroups: []
+    realmRoles:
+      - "admin"
+webAuthnPolicySignatureAlgorithms:
+  - "ES256"
+  - "RS256"
+webAuthnPolicyPasswordlessSignatureAlgorithms:
+  - "ES256"
+  - "RS256"
+clients:
+  - clientId: "admin-cli"
+    name: "${client_admin-cli}"
+    redirectUris: []
+    webOrigins: []
+    standardFlowEnabled: false
+    directAccessGrantsEnabled: true
+    publicClient: true
+    frontchannelLogout: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "false"
+      client.use.lightweight.access.token.enabled: "true"
+    nodeReRegistrationTimeout: 0
+    access: {}
+  - clientId: "broker"
+    name: "${client_broker}"
+    redirectUris: []
+    webOrigins: []
+    bearerOnly: true
+    publicClient: false
+    frontchannelLogout: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "true"
+    fullScopeAllowed: false
+    nodeReRegistrationTimeout: 0
+    access: {}
+  - clientId: "infra-realm"
+    name: "infra Realm"
+    redirectUris: []
+    webOrigins: []
+    bearerOnly: true
+    publicClient: false
+    frontchannelLogout: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "true"
+    fullScopeAllowed: false
+    nodeReRegistrationTimeout: 0
+    defaultClientScopes: []
+    optionalClientScopes: []
+    access: {}
+  - clientId: "chorus-realm"
+    name: "chorus Realm"
+    redirectUris: []
+    webOrigins: []
+    bearerOnly: true
+    publicClient: false
+    frontchannelLogout: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "true"
+    fullScopeAllowed: false
+    nodeReRegistrationTimeout: 0
+    defaultClientScopes: []
+    optionalClientScopes: []
+    access: {}
+  - clientId: "master-realm"
+    name: "master Realm"
+    redirectUris: []
+    webOrigins: []
+    bearerOnly: true
+    publicClient: false
+    frontchannelLogout: false
+    protocol: "openid-connect"
+    attributes:
+      realm_client: "true"
+    fullScopeAllowed: false
+    nodeReRegistrationTimeout: 0
+    access: {}
+clientScopes:
+  - name: "acr"
+    description: "OpenID Connect scope for add acr (authentication context class reference)\
+      \ to the token"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "false"
+      display.on.consent.screen: "false"
+    protocolMappers:
+      - name: "acr loa level"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-acr-mapper"
+        consentRequired: false
+        config:
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+  - name: "organization"
+    description: "Additional claims about the organization a subject belongs to"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "true"
+      consent.screen.text: "${organizationScopeConsentText}"
+      display.on.consent.screen: "true"
+    protocolMappers:
+      - name: "organization"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-organization-membership-mapper"
+        consentRequired: false
+        config:
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "organization"
+          jsonType.label: "String"
+          multivalued: "true"
+  - name: "microprofile-jwt"
+    description: "Microprofile - JWT built-in scope"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "true"
+      display.on.consent.screen: "false"
+    protocolMappers:
+      - name: "groups"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usermodel-realm-role-mapper"
+        consentRequired: false
+        config:
+          introspection.token.claim: "true"
+          multivalued: "true"
+          user.attribute: "foo"
+          id.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "groups"
+          jsonType.label: "String"
+      - name: "upn"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usermodel-attribute-mapper"
+        consentRequired: false
+        config:
+          introspection.token.claim: "true"
+          userinfo.token.claim: "true"
+          user.attribute: "username"
+          id.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "upn"
+          jsonType.label: "String"
+  - name: "basic"
+    description: "OpenID Connect scope for add all basic claims to the token"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "false"
+      display.on.consent.screen: "false"
+    protocolMappers:
+      - name: "auth_time"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usersessionmodel-note-mapper"
+        consentRequired: false
+        config:
+          user.session.note: "AUTH_TIME"
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "auth_time"
+          jsonType.label: "long"
+      - name: "sub"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-sub-mapper"
+        consentRequired: false
+        config:
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+  - name: "service_account"
+    description: "Specific scope for a client enabled for service accounts"
+    protocol: "openid-connect"
+    attributes:
+      include.in.token.scope: "false"
+      display.on.consent.screen: "false"
+    protocolMappers:
+      - name: "Client IP Address"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usersessionmodel-note-mapper"
+        consentRequired: false
+        config:
+          user.session.note: "clientAddress"
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "clientAddress"
+          jsonType.label: "String"
+      - name: "Client ID"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usersessionmodel-note-mapper"
+        consentRequired: false
+        config:
+          user.session.note: "client_id"
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "client_id"
+          jsonType.label: "String"
+      - name: "Client Host"
+        protocol: "openid-connect"
+        protocolMapper: "oidc-usersessionmodel-note-mapper"
+        consentRequired: false
+        config:
+          user.session.note: "clientHost"
+          id.token.claim: "true"
+          introspection.token.claim: "true"
+          access.token.claim: "true"
+          claim.name: "clientHost"
+          jsonType.label: "String"
+identityProviders:
+  - alias: "google"
+    displayName: ""
+    providerId: "google"
+    enabled: true
+    updateProfileFirstLoginMode: "on"
+    trustEmail: false
+    storeToken: false
+    addReadTokenRoleOnCreate: false
+    authenticateByDefault: false
+    linkOnly: false
+    hideOnLogin: false
+    config:
+      offlineAccess: "true"
+      acceptsPromptNoneForwardFromClient: "false"
+      clientId: "$(GOOGLE_CLIENT_ID)"
+      disableUserInfo: "true"
+      filteredByClaim: "false"
+      syncMode: "FORCE"
+      clientSecret: "$(GOOGLE_CLIENT_SECRET)"
+      caseSensitiveOriginalUsername: "false"
+      defaultScope: "email openid"
+attributes: {}
+keycloakVersion: "26.1.5"

--- a/charts/keycloakx/templates/certificate.yaml
+++ b/charts/keycloakx/templates/certificate.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.certificate.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Release.Name }}-cert
+spec:
+  secretName: {{ .Values.certificate.secretName | default (printf "%s-secret" .Release.Name) | quote }}
+
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+
+  duration: {{ .Values.certificate.duration }}
+  renewBefore: {{ .Values.certificate.renewBefore }}
+
+  isCA: false
+  usages:
+    - server auth
+    - client auth
+
+  subject:
+    organizations:
+      - chorus
+
+  uris:
+    - spiffe://cluster.local/ns/{{ .Release.Namespace }}
+  privateKey:
+    rotationPolicy: Always
+
+  issuerRef:
+    name: {{ .Values.certificate.issuerRef.name }}
+    kind: {{ .Values.certificate.issuerRef.kind | default "Issuer" }}
+{{- end }}

--- a/charts/keycloakx/templates/ciliumnetworkpolicy.yaml
+++ b/charts/keycloakx/templates/ciliumnetworkpolicy.yaml
@@ -1,0 +1,34 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ printf "%s-ingress-restrict" .Release.Name | quote }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  # Scoped to this release so it doesn't collide with another keycloak chart
+  # briefly coexisting in the same namespace.
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- if .Values.allowedIngressNamespaces }}
+  ingress:
+    - fromEndpoints:
+        {{- range .Values.allowedIngressNamespaces }}
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: {{ . | quote }}
+        {{- end }}
+      toPorts:
+        - ports:
+            # HTTP, management/metrics. Add 7800/TCP if replicas > 1 (jgroups).
+            - port: "8080"
+              protocol: TCP
+            - port: "9000"
+              protocol: TCP
+  {{- else }}
+  ingress: []
+  {{- end }}

--- a/charts/keycloakx/templates/client-config.yaml
+++ b/charts/keycloakx/templates/client-config.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-client-config" .Release.Name | quote }}
+  namespace: {{ .Release.Namespace }}
+data:
+{{- if .Values.client.chorus }}
+  # Remote cluster clients
+  # chorus
+  CHORUS_ROOT_URL: {{ .Values.client.chorus.rootUrl | quote }}
+  CHORUS_ADMIN_URL: {{ .Values.client.chorus.adminUrl | quote }}
+  CHORUS_BASE_URL: {{ .Values.client.chorus.baseUrl | quote }}
+  CHORUS_REDIRECT_URIS: {{ .Values.client.chorus.redirectUris | quote }}
+  CHORUS_WEB_ORIGINS: {{ .Values.client.chorus.webOrigins | quote }}
+  # matomo
+  MATOMO_ROOT_URL: {{ .Values.client.matomo.rootUrl | quote }}
+  MATOMO_ADMIN_URL: {{ .Values.client.matomo.adminUrl | quote }}
+  MATOMO_BASE_URL: {{ .Values.client.matomo.baseUrl | quote }}
+  MATOMO_REDIRECT_URIS: {{ .Values.client.matomo.redirectUris | quote }}
+  MATOMO_WEB_ORIGINS: {{ .Values.client.matomo.webOrigins | quote }}
+{{- else }}
+  # Build cluster clients
+  # argo-cd
+  ARGO_CD_ROOT_URL: {{ .Values.client.argocd.rootUrl | quote }}
+  ARGO_CD_ADMIN_URL: {{ .Values.client.argocd.adminUrl | quote }}
+  ARGO_CD_BASE_URL: {{ .Values.client.argocd.baseUrl | quote }}
+  ARGO_CD_REDIRECT_URIS: {{ .Values.client.argocd.redirectUris | quote }}
+  ARGO_CD_WEB_ORIGINS: {{ .Values.client.argocd.webOrigins | quote }}
+  # argo-workflows
+  ARGO_WORKFLOWS_ROOT_URL: {{ .Values.client.argoWorkflows.rootUrl | quote }}
+  ARGO_WORKFLOWS_ADMIN_URL: {{ .Values.client.argoWorkflows.adminUrl | quote }}
+  ARGO_WORKFLOWS_BASE_URL: {{ .Values.client.argoWorkflows.baseUrl | quote }}
+  ARGO_WORKFLOWS_REDIRECT_URIS: {{ .Values.client.argoWorkflows.redirectUris | quote }}
+  ARGO_WORKFLOWS_WEB_ORIGINS: {{ .Values.client.argoWorkflows.webOrigins | quote }}
+{{- end }}
+  # Common clients
+  # alertmanager
+  ALERTMANAGER_ROOT_URL: {{ .Values.client.alertmanager.rootUrl | quote }}
+  ALERTMANAGER_ADMIN_URL: {{ .Values.client.alertmanager.adminUrl | quote }}
+  ALERTMANAGER_BASE_URL: {{ .Values.client.alertmanager.baseUrl | quote }}
+  ALERTMANAGER_REDIRECT_URIS: {{ .Values.client.alertmanager.redirectUris | quote }}
+  ALERTMANAGER_WEB_ORIGINS: {{ .Values.client.alertmanager.webOrigins | quote }}
+  # grafana
+  GRAFANA_ROOT_URL: {{ .Values.client.grafana.rootUrl | quote }}
+  GRAFANA_ADMIN_URL: {{ .Values.client.grafana.adminUrl | quote }}
+  GRAFANA_BASE_URL: {{ .Values.client.grafana.baseUrl | quote }}
+  GRAFANA_REDIRECT_URIS: {{ .Values.client.grafana.redirectUris | quote }}
+  GRAFANA_WEB_ORIGINS: {{ .Values.client.grafana.webOrigins | quote }}
+  # harbor
+  HARBOR_ROOT_URL: {{ .Values.client.harbor.rootUrl | quote }}
+  HARBOR_ADMIN_URL: {{ .Values.client.harbor.adminUrl | quote }}
+  HARBOR_BASE_URL: {{ .Values.client.harbor.baseUrl | quote }}
+  HARBOR_REDIRECT_URIS: {{ .Values.client.harbor.redirectUris | quote }}
+  HARBOR_WEB_ORIGINS: {{ .Values.client.harbor.webOrigins | quote }}
+  # juicefs-dashboard
+  JUICEFS_DASHBOARD_ROOT_URL: {{ index .Values.client "juicefs-dashboard" "rootUrl" | quote }}
+  JUICEFS_DASHBOARD_ADMIN_URL: {{ index .Values.client "juicefs-dashboard" "adminUrl" | quote }}
+  JUICEFS_DASHBOARD_BASE_URL: {{ index .Values.client "juicefs-dashboard" "baseUrl" | quote }}
+  JUICEFS_DASHBOARD_REDIRECT_URIS: {{ index .Values.client "juicefs-dashboard" "redirectUris" | quote }}
+  JUICEFS_DASHBOARD_WEB_ORIGINS: {{ index .Values.client "juicefs-dashboard" "webOrigins" | quote }}
+  # prometheus
+  PROMETHEUS_ROOT_URL: {{ .Values.client.prometheus.rootUrl | quote }}
+  PROMETHEUS_ADMIN_URL: {{ .Values.client.prometheus.adminUrl | quote }}
+  PROMETHEUS_BASE_URL: {{ .Values.client.prometheus.baseUrl | quote }}
+  PROMETHEUS_REDIRECT_URIS: {{ .Values.client.prometheus.redirectUris | quote }}
+  PROMETHEUS_WEB_ORIGINS: {{ .Values.client.prometheus.webOrigins | quote }}

--- a/charts/keycloakx/templates/keycloak-config-cli-job.yaml
+++ b/charts/keycloakx/templates/keycloak-config-cli-job.yaml
@@ -1,0 +1,92 @@
+{{- if .Values.keycloakConfigCli.enabled }}
+{{- $relativePath := .Values.keycloak.http.relativePath | default "/" -}}
+{{- /* Mirror keycloak.fullname so KEYCLOAK_URL resolves the subchart's Service. */ -}}
+{{- $kcName := default "keycloak" .Values.keycloak.nameOverride -}}
+{{- $kcFullname := .Release.Name -}}
+{{- if not (contains $kcName .Release.Name) -}}
+{{- $kcFullname = printf "%s-%s" .Release.Name $kcName -}}
+{{- end -}}
+{{- if .Values.keycloak.fullnameOverride -}}
+{{- $kcFullname = .Values.keycloak.fullnameOverride -}}
+{{- end -}}
+{{- $defaultUrl := printf "http://%s-http.%s.svc.cluster.local%s" $kcFullname .Release.Namespace $relativePath -}}
+{{- $keycloakUrl := default $defaultUrl .Values.keycloakConfigCli.keycloakUrl -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ printf "%s-config-cli" .Release.Name | quote }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+    app.kubernetes.io/name: keycloak-config-cli
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.keycloakConfigCli.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  backoffLimit: {{ .Values.keycloakConfigCli.backoffLimit | default 3 }}
+  {{- if .Values.keycloakConfigCli.cleanupAfterFinished.enabled }}
+  ttlSecondsAfterFinished: {{ .Values.keycloakConfigCli.cleanupAfterFinished.seconds | default 600 }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: keycloak-config-cli
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      restartPolicy: Never
+      {{- with .Values.keycloakConfigCli.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: keycloak-config-cli
+          image: "{{ .Values.keycloakConfigCli.image.repository }}:{{ .Values.keycloakConfigCli.image.tag }}"
+          imagePullPolicy: {{ .Values.keycloakConfigCli.image.pullPolicy | default "IfNotPresent" }}
+          {{- with .Values.keycloakConfigCli.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: KEYCLOAK_URL
+              value: {{ $keycloakUrl | quote }}
+            - name: KEYCLOAK_USER
+              value: {{ .Values.keycloakConfigCli.adminUser | quote }}
+            - name: KEYCLOAK_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.keycloakConfigCli.adminPasswordSecret.name | quote }}
+                  key: {{ .Values.keycloakConfigCli.adminPasswordSecret.key | quote }}
+            - name: KEYCLOAK_SSLVERIFY
+              value: {{ .Values.keycloakConfigCli.sslVerify | quote }}
+            - name: IMPORT_FILES_LOCATIONS
+              value: "/realm/*.yaml"
+            - name: IMPORT_VARSUBSTITUTION_ENABLED
+              value: "true"
+            - name: IMPORT_CACHE_ENABLED
+              value: "false"
+            - name: IMPORT_REMOTESTATE_ENCRYPTIONKEY
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-remotestate-encryption-key
+                  key: encryptionKey
+          envFrom:
+            - configMapRef:
+                name: {{ printf "%s-client-config" .Release.Name | quote }}
+            - secretRef:
+                name: {{ .Values.client.existingSecret | default "keycloak-client-secret" }}
+          volumeMounts:
+            - name: realm-config
+              mountPath: /realm/
+              readOnly: true
+          {{- with .Values.keycloakConfigCli.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: realm-config
+          configMap:
+            name: {{ printf "%s-realm-config" .Release.Name | quote }}
+{{- end }}

--- a/charts/keycloakx/templates/realm-config.yaml
+++ b/charts/keycloakx/templates/realm-config.yaml
@@ -1,0 +1,22 @@
+{{- $currentScope := . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-realm-config" .Release.Name | quote }}
+  namespace: {{ $currentScope.Release.Namespace }}
+data:
+{{- if .Values.client.chorus }}
+{{- range $path, $_ :=  .Files.Glob  "files/realm/remote/*-realm.yaml" }}
+  {{ base $path }}: |-
+{{- with $currentScope }}
+{{ .Files.Get $path | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- else }}
+{{- range $path, $_ :=  .Files.Glob  "files/realm/build/*-realm.yaml" }}
+  {{ base $path }}: |-
+{{- with $currentScope }}
+{{ .Files.Get $path | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -31,11 +31,11 @@ keycloak:
 
   resources:
     requests:
-      cpu: "500m"
-      memory: "1Gi"
-    limits:
       cpu: "1"
       memory: "2Gi"
+    limits:
+      cpu: "2"
+      memory: "2560Mi"
 
   priorityClassName: "high-priority"
 

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -39,13 +39,13 @@ keycloak:
 
   priorityClassName: "high-priority"
 
-  # Single Micrometer endpoint on the management port (9000); per-realm
-  # metrics are exposed as labels on the same series.
+  # Opt in per-env. Single Micrometer endpoint on the management port
+  # (9000); per-realm metrics are exposed as labels on the same series.
   metrics:
-    enabled: true
+    enabled: false
 
   serviceMonitor:
-    enabled: true
+    enabled: false
 
   # `hostname` is the only required per-env override.
   database:

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -1,0 +1,214 @@
+keycloak:
+  # No fullnameOverride — release name + chart helper produces resource names
+  # like `<release>-http`, matching the cluster's `<env>-<app>-...` convention.
+  nameOverride: keycloak
+
+  image:
+    repository: quay.io/keycloak/keycloak
+
+  # The image entrypoint requires an explicit subcommand; defaults are empty.
+  command:
+    - "/opt/keycloak/bin/kc.sh"
+  args:
+    - "start"
+
+  http:
+    relativePath: "/"
+
+  proxy:
+    enabled: true
+    mode: forwarded
+    http:
+      enabled: true
+
+  podSecurityContext:
+    fsGroup: 1000
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+
+  replicas: 1
+
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "1Gi"
+    limits:
+      cpu: "1"
+      memory: "2Gi"
+
+  priorityClassName: "high-priority"
+
+  # Single Micrometer endpoint on the management port (9000); per-realm
+  # metrics are exposed as labels on the same series.
+  metrics:
+    enabled: true
+
+  serviceMonitor:
+    enabled: true
+
+  # `hostname` is the only required per-env override.
+  database:
+    vendor: postgres
+    port: 5432
+    database: keycloak
+    username: keycloak
+    existingSecret: keycloak-db-secret
+    existingSecretKey: password
+
+  # Per-env values can replace this entire block to add extra env vars.
+  extraEnv: |
+    - name: KC_LOG_CONSOLE_OUTPUT
+      value: "json"
+    - name: KC_BOOTSTRAP_ADMIN_USERNAME
+      value: "admin"
+    - name: KC_BOOTSTRAP_ADMIN_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: keycloak-secret
+          key: adminPassword
+
+  # We render our own CiliumNetworkPolicy below.
+  networkPolicy:
+    enabled: false
+
+  # Default disabled; env values supply rules + tls.
+  ingress:
+    enabled: false
+    ingressClassName: nginx
+
+  dbchecker:
+    enabled: true
+
+# Realm import as a Helm/Argo PostSync hook (keycloakx does not bundle one).
+keycloakConfigCli:
+  enabled: true
+
+  image:
+    repository: docker.io/adorsys/keycloak-config-cli
+    # adorsys publishes tags as `<cli-version>-<kc-version>` on Docker Hub.
+    tag: "6.5.0-26.5.4"
+    pullPolicy: IfNotPresent
+
+  adminUser: admin
+  adminPasswordSecret:
+    name: keycloak-secret
+    key: adminPassword
+
+  # Override only if the in-cluster Keycloak URL needs to differ from the
+  # default `http://<release>-http.<namespace>.svc.cluster.local<relativePath>`.
+  keycloakUrl: ""
+
+  sslVerify: "false"
+
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded,BeforeHookCreation
+
+  backoffLimit: 3
+
+  cleanupAfterFinished:
+    enabled: true
+    seconds: 600
+
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    fsGroup: 1000
+
+  securityContext:
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 1000
+    capabilities:
+      drop:
+        - ALL
+
+# Client configuration consumed by keycloak-config-cli via IMPORT_VARSUBSTITUTION.
+client:
+  existingSecret: keycloak-client-secret
+  # Build cluster clients
+  # argocd:
+  #   rootUrl: "http://argo-cd.local"
+  #   adminUrl: "http://argo-cd.local"
+  #   baseUrl: "/applications"
+  #   redirectUris: '["http://argo-cd.local/auth/callback"]'
+  #   webOrigins: '["http://argo-cd.local"]'
+  # argoWorkflows:
+  #   rootUrl: "http://argo-workflows.local"
+  #   adminUrl: "http://argo-workflows.local"
+  #   baseUrl: "/workflows/argo"
+  #   redirectUris: '["http://argo-workflows.local/oauth2/callback"]'
+  #   webOrigins: '["http://argo-workflows.local"]'
+  # Remote cluster clients
+  chorus:
+    rootUrl: "http://backend.local"
+    adminUrl: "http://backend.local"
+    baseUrl: "/"
+    redirectUris: '["http://backend.local/*","http://chorus.local/*"]'
+    webOrigins: '["http://backend.local/*","http://chorus.local/*"]'
+  matomo:
+    rootUrl: "http://makoto.local"
+    adminUrl: "http://makoto.local"
+    baseUrl: "/"
+    redirectUris: '["http://makoto.local/index.php?module=LoginOIDC&action=callback&provider=oidc","http://makoto.local"]'
+    webOrigins: '["http://makoto.local"]'
+  # Common clients
+  alertmanager:
+    rootUrl: "http://alertmanager.local"
+    adminUrl: "http://alertmanager.local"
+    baseUrl: "/"
+    redirectUris: '["http://alertmanager.local/*"]'
+    webOrigins: '["http://alertmanager.local"]'
+  grafana:
+    rootUrl: "http://grafana.local"
+    adminUrl: "http://grafana.local"
+    baseUrl: "/"
+    redirectUris: '["http://grafana.local/login/generic_oauth"]'
+    webOrigins: '["http://grafana.local"]'
+  harbor:
+    rootUrl: "http://harbor.local"
+    adminUrl: "http://harbor.local"
+    baseUrl: "/harbor/projects"
+    redirectUris: '["http://harbor.local/c/oidc/callback"]'
+    webOrigins: '["http://harbor.local"]'
+  juicefs-dashboard:
+    rootUrl: "http://juicefs-dashboard.local"
+    adminUrl: "http://juicefs-dashboard.local"
+    baseUrl: "/"
+    redirectUris: '["http://juicefs-dashboard.local/oauth2/callback"]'
+    webOrigins: '["http://juicefs-dashboard.local"]'
+  prometheus:
+    rootUrl: "http://prometheus.local"
+    adminUrl: "http://prometheus.local"
+    baseUrl: "/"
+    redirectUris: '["http://prometheus.local/*","http://alertmanager.local/*"]'
+    webOrigins: '["http://prometheus.local"]'
+
+# Optional workload-level cert; default path is edge TLS at the Ingress.
+certificate:
+  enabled: false
+
+  secretName: keycloak-tls
+
+  duration: 2169h # 90d
+  renewBefore: 360h # 15d
+
+  issuerRef:
+    name: CHANGEME-issuer
+
+# CiliumNetworkPolicy ingress allow-list. An empty list = deny-all ingress.
+allowedIngressNamespaces:
+  - envoy-gateway-system
+  - backend
+  - harbor
+  - prometheus
+  - keycloak

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -77,8 +77,10 @@ keycloak:
     enabled: false
     ingressClassName: nginx
 
+  # Opt in per-env after `database.hostname` is set, otherwise the subchart's
+  # `required` check fails at render time.
   dbchecker:
-    enabled: true
+    enabled: false
 
 # Realm import as a Helm/Argo PostSync hook (keycloakx does not bundle one).
 keycloakConfigCli:


### PR DESCRIPTION
## Drop-in replacement target for the bitnami-based keycloak chart

Bitnami moved their Helm charts behind a paid offering, so we need a non-bitnami Keycloak chart to migrate towards. This adds a new umbrella chart wrapping the [codecentric/keycloakx][] chart, aliased to `keycloak` so per-env values keep using the `keycloak.*` key path.

Functionally equivalent to `charts/keycloak` — same realm import flow, same secrets, same CiliumNetworkPolicy posture — with a few notable changes:

- Realm import is performed by a chart-owned `keycloak-config-cli` Job (`templates/keycloak-config-cli-job.yaml`) since codecentric/keycloakx does not bundle one. Runs as a Helm/Argo PostSync hook and reuses the existing `keycloak-realm-config` / `keycloak-client-config` ConfigMaps and `keycloak-client-secret` Secret.
- Resource naming follows the cluster's `<release>-...` convention. The chart sets only `nameOverride: keycloak` (no `fullnameOverride`), so an Argo release named `chorus-int-keycloak` produces a Service named `chorus-int-keycloak-http`. At cutover the gateway routes only need their `serviceName` flipped (suffix `-http`).
- All chart-owned resources (ConfigMaps, Job, CiliumNetworkPolicy) are release-prefixed so this chart and the bitnami-based `charts/keycloak` can briefly coexist in the same namespace during the cutover sync window without colliding.
- Admin bootstrap uses Keycloak 26's `KC_BOOTSTRAP_ADMIN_USERNAME` / `KC_BOOTSTRAP_ADMIN_PASSWORD` env vars wired from the existing `keycloak-secret` via the chart-level `keycloak.extraEnv` block.

Two non-obvious upstream behaviors handled in chart defaults:

- The codecentric chart leaves `command` / `args` empty, which makes the `quay.io/keycloak/keycloak` image entrypoint print help and never start. The chart sets them explicitly to `kc.sh start`.
- `adorsys/keycloak-config-cli` uses a `<cli-version>-<kc-version>` tag scheme on Docker Hub — there is no bare `6.x.y` tag. Default pin `6.5.0-26.5.4`, matching the keycloak image tag.

Validated end-to-end on chorus-int by cloning `keycloak-db` into a parallel namespace, deploying this chart against the clone, and confirming Liquibase 26.1.5 → 26.5.6 schema migration, realm import, and OIDC discovery all work unchanged. The bitnami `charts/keycloak` is unchanged — both charts now coexist; per-env Argo apps can adopt the new chart at their own pace.

Chart `0.0.1` (initial).

[codecentric/keycloakx]: https://github.com/codecentric/helm-charts/tree/master/charts/keycloakx