### PR TITLE
fix(chorus-gateway): correct openGrpcRoutes appProtocol note

### DIFF
--- a/charts/chorus-gateway/Chart.yaml
+++ b/charts/chorus-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: chorus-gateway
 description: Envoy Gateway routes and SecurityPolicies for CHORUS services
-version: 0.0.18
+version: 0.0.19
 maintainers:
   - name: iDmple
     email: nathalie.casati@chuv.ch

--- a/charts/chorus-gateway/values.yaml
+++ b/charts/chorus-gateway/values.yaml
@@ -197,11 +197,9 @@ internalTcpRoutes: []
 
 # Open gRPC routes — accessible from anywhere, no SecurityPolicy restriction.
 # Each entry creates a GRPCRoute and ReferenceGrant. Backend Service must speak
-# gRPC over HTTP/2 (e.g. argo-cd-server, gRPC microservices). To make Envoy use
-# HTTP/2 to the backend, the Service port should advertise it via
-# `appProtocol: kubernetes.io/h2c` (cleartext) or `appProtocol: kubernetes.io/grpc`
-# (TLS) — without this Envoy may default to HTTP/1.1 and the backend will
-# reject framed gRPC.
+# gRPC over HTTP/2 (e.g. argo-cd-server, gRPC microservices). Envoy Gateway uses
+# HTTP/2 to the upstream automatically when the route is a GRPCRoute, so an
+# `appProtocol` on the Service port is not required.
 #
 # Example — argo-cd's gRPC API on a dedicated hostname (Build cluster, where CHORUS isn't deployed):
 #   openGrpcRoutes:


### PR DESCRIPTION
## Correct the appProtocol guidance for openGrpcRoutes

The `openGrpcRoutes:` example comment from #715 inherited a reviewer's note about backend HTTP/2 negotiation that's true for `HTTPRoute` carrying gRPC traffic, but **not** for `GRPCRoute`. Envoy Gateway auto-selects HTTP/2 to the upstream when the route is a GRPCRoute — verified end-to-end against argo-cd-server on chorus-build (the gRPC `argocd login` succeeds without `appProtocol` on the Service port).

Replaces the misleading "you may need appProtocol" wording with a correct statement that GRPCRoute handles upstream protocol selection automatically.

Chart bump `0.0.18 → 0.0.19`. Doc-only change.