### PR TITLE
feat(keycloakx): pin KC image tag and default proxy.mode to xforwarded (0.0.2)

### DIFF
--- a/charts/keycloakx/Chart.yaml
+++ b/charts/keycloakx/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Keycloak.X - Open Source Identity and Access Management for Modern Applications and Services
 name: keycloakx
-version: 0.0.1
+version: 0.0.2
 dependencies:
   - name: keycloakx
     version: 7.1.11

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -210,8 +210,6 @@ certificate:
 
 # CiliumNetworkPolicy ingress allow-list. An empty list = deny-all ingress.
 allowedIngressNamespaces:
-  - envoy-gateway-system
-  - backend
-  - harbor
-  - prometheus
-  - keycloak
+  - envoy-gateway-system  # gateway's OIDC filter
+  - backend               # chorus backend in-cluster call
+  - keycloak              # intra-namespace (config-cli Job)

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -5,6 +5,7 @@ keycloak:
 
   image:
     repository: quay.io/keycloak/keycloak
+    tag: "26.5.6"
 
   # The image entrypoint requires an explicit subcommand; defaults are empty.
   command:
@@ -17,7 +18,7 @@ keycloak:
 
   proxy:
     enabled: true
-    mode: forwarded
+    mode: xforwarded
     http:
       enabled: true
 

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -57,7 +57,9 @@ keycloak:
     existingSecret: keycloak-db-secret
     existingSecretKey: password
 
-  # Per-env values can replace this entire block to add extra env vars.
+  # Per-env values can replace this entire block to add extra env vars. If
+  # replaced, copy the user-event-metrics flags below to keep parity with the
+  # legacy bitnami release's per-realm event counters.
   extraEnv: |
     - name: KC_LOG_CONSOLE_OUTPUT
       value: "json"
@@ -68,6 +70,10 @@ keycloak:
         secretKeyRef:
           name: keycloak-secret
           key: adminPassword
+    - name: KC_FEATURES
+      value: "user-event-metrics"
+    - name: KC_EVENT_METRICS_USER_ENABLED
+      value: "true"
 
   # We render our own CiliumNetworkPolicy below.
   networkPolicy:


### PR DESCRIPTION
## keycloakx chart — better defaults

Two adjustments to the chart's baked-in defaults so per-env overrides drop to
the bare minimum.

### Changes

- `charts/keycloakx/values.yaml`
  - Pin `keycloak.image.tag: "26.5.6"` — tracks the codecentric subchart's
    current default. Pinning it once at the chart level prevents silent drift
    if the dependency bumps without a chorus-tre release.
  - Switch `keycloak.proxy.mode: forwarded` → `xforwarded`. Envoy Gateway is
    the chorus-tre standard, so this belongs in the chart, not in every env.
- `charts/keycloakx/Chart.yaml` — bump `0.0.1` → `0.0.2`.

### Consumer impact

`environments` PR https://github.com/CHORUS-TRE/environments/pull/1681 will
follow up to:
- bump `chorus-int/keycloakx/config.json` to `0.0.2`,
- drop the now-redundant `image.tag` and `proxy.mode` overrides from
  `chorus-int/keycloakx/values.yaml`,
- and clean up the other duplicates that were already matching chart defaults.

No other consumer of the chart exists yet.