### PR TITLE
fix(didata): support node-local-dns and CoreDNS in CNP DNS egress

### DIFF
--- a/charts/didata/Chart.yaml
+++ b/charts/didata/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.19
+version: 0.0.20
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/didata/templates/ciliumnetworkpolicy.yaml
+++ b/charts/didata/templates/ciliumnetworkpolicy.yaml
@@ -31,19 +31,30 @@ spec:
   # Note: CiliumNetworkPolicy uses different format than K8s NetworkPolicy
   # For L7 WAF mode, define specific Cilium egress rules in environment-specific values
   egress:
-  # Always allow DNS resolution.
-  # Use kube-dns entity to auto-detect DNS infrastructure (kube-dns or node-local-dns).
-  - toEntities:
-    - kube-dns
+  # Allow DNS to in-cluster CoreDNS pods (clusters without node-local-dns).
+  # Targets the kube-dns Service backing pods by their label.
+  - toEndpoints:
+    - matchLabels:
+        "k8s:io.kubernetes.pod.namespace": kube-system
+        app: coredns
     toPorts:
     - ports:
       - port: "53"
         protocol: UDP
       - port: "53"
         protocol: TCP
-      rules:
-        dns:
-        - matchPattern: "*"
+  # Allow DNS to node-local-dns (host network, link-local IP 169.254.x.x).
+  # Cilium classifies that link-local IP as the "world" entity (not "host" and
+  # not the node-local-dns pod identity, since the pod runs hostNetwork=true).
+  # Bounded to port 53 — does not allow general external egress.
+  - toEntities:
+    - world
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
   {{- if .Values.networkPolicy.egress }}
     {{- toYaml .Values.networkPolicy.egress | nindent 2 }}
   {{- end }}


### PR DESCRIPTION
## Fix DNS egress in didata CiliumNetworkPolicy

The 0.0.19 CNP egress used `toEntities: kube-dns`, which is not a valid Cilium entity. When `enabled_l7_waf: true` (the chart default for didata), Cilium silently treats the rule as having no destinations → DNS lookups from the didata pod are blocked → "unknown host".

Same root cause and fix as https://github.com/CHORUS-TRE/chorus-tre/pull/714 for `i2b2-wildfly`. Empirical testing on chorus-demo (which runs both CoreDNS and node-local-dns) showed:

| Egress rule | Result |
|---|---|
| `toEntities: [kube-dns]` (chart default before this fix) | Invalid entity, silently dropped |
| `toEndpoints: app=coredns` (in-cluster CoreDNS path) | Allowed |
| `toEntities: [world]` (link-local IP for node-local-dns) | Allowed |

The fix replaces the bogus rule with two egress rules:

- `toEndpoints: kube-system + app=coredns` on port 53 — covers in-cluster CoreDNS (any cluster without node-local-dns).
- `toEntities: [world]` on port 53 — covers node-local-dns link-local destination. Bounded to port 53; does not open general external egress.

Both rules are gated by the policy's `endpointSelector` so only didata pods can use them.

The K8s `NetworkPolicy` template is unchanged — it already opens port 53 to any destination, which works for both DNS modes.

Bumps chart `0.0.19 → 0.0.20`. Active fix (didata's `enabled_l7_waf` defaults to `true`, so the CNP renders whenever didata is deployed).