### PR TITLE
fix(chorus-ci): bump golang image to 1.26-bookworm (0.0.145)

### DIFF
--- a/charts/chorus-ci/Chart.yaml
+++ b/charts/chorus-ci/Chart.yaml
@@ -18,4 +18,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.144
+version: 0.0.145

--- a/charts/chorus-ci/values.yaml
+++ b/charts/chorus-ci/values.yaml
@@ -50,7 +50,7 @@ chorusWorkbenchOperator:
     storageClassName: ""
     storageRequest: "40Gi"
   golang:
-    tag: "1.25-bookworm"
+    tag: "1.26-bookworm"
 
 chorusBackend:
   dockerDataStorage:


### PR DESCRIPTION
## Bump CI Go image to 1.26-bookworm

Pairs with workbench-operator PR https://github.com/CHORUS-TRE/workbench-operator/pull/219, which bumped `go.mod` from `go 1.25.0` to `go 1.26.0` (driven by the `k8s.io/* 0.36` and `controller-runtime 0.24` updates).

The CI runner pulls its Go image from `chorusWorkbenchOperator.golang.tag` in this chart's values. With the runner still on `1.25-bookworm`, the e2e job fails with `go: go.mod requires go >= 1.26.0 (running go 1.25.3; GOTOOLCHAIN=local)`.

### Changes
- `charts/chorus-ci/values.yaml`: `chorusWorkbenchOperator.golang.tag` `"1.25-bookworm" → "1.26-bookworm"`.
- `charts/chorus-ci/Chart.yaml`: `version 0.0.144 → 0.0.145`.

### Deployment
Companion environments PR will bump `chorus-build/chorus-ci/config.json` to `0.0.145` so the new chart lands on the build cluster. `unil-build-dev` keeps its own pin (`0.0.129`) — not in scope.