### PR TITLE
feat(gitlab): autoSignInWithProvider openid_connect (0.0.10)

### DIFF
--- a/charts/gitlab/Chart.yaml
+++ b/charts/gitlab/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Web-based Git-repository manager with wiki and issue-tracking features.
 name: gitlab
-version: 0.0.9
+version: 0.0.10
 dependencies:
   - name: gitlab
     version: 9.9.3

--- a/charts/gitlab/values.yaml
+++ b/charts/gitlab/values.yaml
@@ -63,6 +63,7 @@ gitlab:
         allowSingleSignOn: ["openid_connect"]
         blockAutoCreatedUsers: true
         autoLinkUser: ["openid_connect"]
+        autoSignInWithProvider: openid_connect
         providers:
           - secret: gitlab-oidc-secret
             key: provider

--- a/charts/gitlab/values.yaml
+++ b/charts/gitlab/values.yaml
@@ -63,6 +63,8 @@ gitlab:
         allowSingleSignOn: ["openid_connect"]
         blockAutoCreatedUsers: true
         autoLinkUser: ["openid_connect"]
+        # Auto-redirect unauthenticated visitors to the OIDC provider.
+        # Recovery hatch on OIDC outage / for the root admin: /users/sign_in?auto_sign_in=false
         autoSignInWithProvider: openid_connect
         providers:
           - secret: gitlab-oidc-secret


### PR DESCRIPTION
## Auto-redirect unauthenticated GitLab visitors to the OIDC provider

Add `gitlab.global.appConfig.omniauth.autoSignInWithProvider: openid_connect` so users hitting GitLab without an active session are sent straight to the OIDC provider. If they already have an active SSO session there, they bounce right back into GitLab without ever seeing the GitLab sign-in page or having to click "Sign in with CHORUS".

### Behaviour
- Unauthenticated visitor → `/users/sign_in` → 302 to OIDC provider → returns authenticated.
- Already-authenticated visitor → unaffected.
- Non-OIDC sign-in (root admin via `initialRootPassword`) → use `/users/sign_in?auto_sign_in=false` to bypass the redirect for that one request. The bypass is implemented in GitLab's Rails app — not in the Helm chart, but reachable through the standard sign-in route.

### Naming note
The Helm value key is `autoSignInWithProvider` (camelCase). The snake_case `auto_sign_in_with_provider` is GitLab's runtime config-file key in `gitlab.yml` — the upstream subchart's `_omniauth.tpl` reads `.omniauth.autoSignInWithProvider` and renders the snake_case form into that config. Our wrapper chart only sets the value; the camelCase ↔ snake_case translation is upstream's. Verified against `gitlab/9.9.3` — both `gitlab/values.yaml:627` and `gitlab/charts/gitlab/charts/webservice/values.yaml:419` declare `autoSignInWithProvider`, and `gitlab/templates/_omniauth.tpl:5-6` does the rendering.

### Risks (non-blocking)
- **OIDC outage = full lockout for normal users**. The `/users/sign_in?auto_sign_in=false` URL is the recovery hatch — worth adding to the cluster runbook so on-call has it ready before an OIDC incident.
- **First-time OIDC users still get blocked**: this chart already ships `blockAutoCreatedUsers: true`, so a never-seen OIDC identity is auto-redirected, authenticated upstream, then lands on GitLab's "blocked" page until an admin unblocks them. Behaviour unchanged from `0.0.9` — just one fewer click before the same block.

### Versions
- `charts/gitlab/Chart.yaml`: `version 0.0.9 → 0.0.10`
- Upstream subchart pin unchanged (`9.9.3`).

### Deployment
Companion env PR https://github.com/CHORUS-TRE/environments/pull/1696 bumps `chorus-int/gitlab/config.json` to `0.0.10`.