### PR TITLE
feat(firecrest-web-ui-v2): bump to 2.6.1 (OIDC support, replaces Keycloak-specific config) (0.0.2)

### DIFF
--- a/charts/firecrest-web-ui-v2/Chart.lock
+++ b/charts/firecrest-web-ui-v2/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: firecrest-web-ui-v2
   repository: https://eth-cscs.github.io/firecrest-ui/helm/
-  version: 2.5.2
-digest: sha256:e3940535ce4f834ad61fbb494f6abd5253d5df2ec4e0eb3c12292d2825807be4
-generated: "2026-03-27T23:15:55.138519+01:00"
+  version: 2.6.1
+digest: sha256:5827f050cc6468fa7b6899684c2baff6c8281b00e3370131f044462ab5034450
+generated: "2026-05-07T15:52:55.960201+02:00"

--- a/charts/firecrest-web-ui-v2/Chart.yaml
+++ b/charts/firecrest-web-ui-v2/Chart.yaml
@@ -4,9 +4,9 @@ description: FirecREST Web UI v2 - web interface for the FirecREST HPC API
 maintainers:
   - name: iDmple
     email: nathalie.casati@chuv.ch
-version: 0.0.1
-appVersion: "2.5.2"
+version: 0.0.2
+appVersion: "2.6.1"
 dependencies:
   - name: firecrest-web-ui-v2
-    version: 2.5.2
+    version: 2.6.1
     repository: https://eth-cscs.github.io/firecrest-ui/helm/

--- a/charts/firecrest-web-ui-v2/values.yaml
+++ b/charts/firecrest-web-ui-v2/values.yaml
@@ -6,7 +6,6 @@ firecrest-web-ui-v2:
   appName: "FirecREST Dashboard"
   customLogo: false
   redisActive: "true"
-  keycloakRealm: "chorus"
 
 ingress:
   enabled: true


### PR DESCRIPTION
## feat(firecrest-web-ui-v2): bump to 2.6.1 (OIDC support, replaces Keycloak-specific config) (0.0.2)

Bumps the upstream `firecrest-web-ui-v2` chart from 2.5.2 to 2.6.1, which switches from Keycloak-specific configuration to standard OIDC.

- New values: `oidcIssuerUrl`, `oidcCallbackUrl`, `oidcPostLogoutRedirectUrl`
- Removed values: `keycloakDomain`, `keycloakRealm`, `keycloakCallbackUrl`, `keycloakLogoutRedirectUrl`
- Secret keys renamed: `keycloak-client-id` → `oidc-client-id`, `keycloak-client-secret` → `oidc-client-secret`
- Lets the app work with non-Keycloak OIDC providers

Environment values and the Kubernetes Secret must be updated alongside this bump.