### PR TITLE
feat(keycloakx): gate juicefs-dashboard client on env opt-in (0.0.3)

### DIFF
--- a/charts/keycloakx/Chart.yaml
+++ b/charts/keycloakx/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Keycloak.X - Open Source Identity and Access Management for Modern Applications and Services
 name: keycloakx
-version: 0.0.2
+version: 0.0.3
 dependencies:
   - name: keycloakx
     version: 7.1.11

--- a/charts/keycloakx/files/realm/remote/infra-realm.yaml
+++ b/charts/keycloakx/files/realm/remote/infra-realm.yaml
@@ -169,6 +169,7 @@ clients:
       - "offline_access"
       - "groups"
     access: {}
+{{- if hasKey .Values.client "juicefs-dashboard" }}
   - clientId: "juicefs-dashboard"
     name: "JuiceFS Dashboard"
     rootUrl: "$(JUICEFS_DASHBOARD_ROOT_URL)"
@@ -202,6 +203,7 @@ clients:
       - "offline_access"
       - "groups"
     access: {}
+{{- end }}
   - clientId: "prometheus"
     name: "Prometheus"
     rootUrl: "$(PROMETHEUS_ROOT_URL)"

--- a/charts/keycloakx/templates/client-config.yaml
+++ b/charts/keycloakx/templates/client-config.yaml
@@ -52,12 +52,14 @@ data:
   HARBOR_BASE_URL: {{ .Values.client.harbor.baseUrl | quote }}
   HARBOR_REDIRECT_URIS: {{ .Values.client.harbor.redirectUris | quote }}
   HARBOR_WEB_ORIGINS: {{ .Values.client.harbor.webOrigins | quote }}
+{{- if hasKey .Values.client "juicefs-dashboard" }}
   # juicefs-dashboard
   JUICEFS_DASHBOARD_ROOT_URL: {{ index .Values.client "juicefs-dashboard" "rootUrl" | quote }}
   JUICEFS_DASHBOARD_ADMIN_URL: {{ index .Values.client "juicefs-dashboard" "adminUrl" | quote }}
   JUICEFS_DASHBOARD_BASE_URL: {{ index .Values.client "juicefs-dashboard" "baseUrl" | quote }}
   JUICEFS_DASHBOARD_REDIRECT_URIS: {{ index .Values.client "juicefs-dashboard" "redirectUris" | quote }}
   JUICEFS_DASHBOARD_WEB_ORIGINS: {{ index .Values.client "juicefs-dashboard" "webOrigins" | quote }}
+{{- end }}
   # prometheus
   PROMETHEUS_ROOT_URL: {{ .Values.client.prometheus.rootUrl | quote }}
   PROMETHEUS_ADMIN_URL: {{ .Values.client.prometheus.adminUrl | quote }}

--- a/charts/keycloakx/templates/realm-config.yaml
+++ b/charts/keycloakx/templates/realm-config.yaml
@@ -9,7 +9,7 @@ data:
 {{- range $path, $_ :=  .Files.Glob  "files/realm/remote/*-realm.yaml" }}
   {{ base $path }}: |-
 {{- with $currentScope }}
-{{ .Files.Get $path | nindent 4 }}
+{{ tpl (.Files.Get $path) . | nindent 4 }}
 {{- end }}
 {{- end }}
 {{- else }}

--- a/charts/keycloakx/values.yaml
+++ b/charts/keycloakx/values.yaml
@@ -189,12 +189,12 @@ client:
     baseUrl: "/harbor/projects"
     redirectUris: '["http://harbor.local/c/oidc/callback"]'
     webOrigins: '["http://harbor.local"]'
-  juicefs-dashboard:
-    rootUrl: "http://juicefs-dashboard.local"
-    adminUrl: "http://juicefs-dashboard.local"
-    baseUrl: "/"
-    redirectUris: '["http://juicefs-dashboard.local/oauth2/callback"]'
-    webOrigins: '["http://juicefs-dashboard.local"]'
+  # juicefs-dashboard: opt-in. Envs that expose a JuiceFS dashboard declare a
+  # client.juicefs-dashboard block here (rootUrl/adminUrl/baseUrl/redirectUris/
+  # webOrigins) and add JUICEFS_DASHBOARD_CLIENT_SECRET to keycloak-client-secret.
+  # When omitted, the client is gated out of infra-realm.yaml and config-cli
+  # skips it cleanly. Do not put placeholder defaults here — they would defeat
+  # the hasKey gate (chart defaults merge under env overrides).
   prometheus:
     rootUrl: "http://prometheus.local"
     adminUrl: "http://prometheus.local"


### PR DESCRIPTION
## Why

config-cli on chorus-dev fails with:

```
ERROR ... Cannot resolve variable 'JUICEFS_DASHBOARD_CLIENT_SECRET' (enableSubstitutionInVariables=true).
```

Root cause: the juicefs-dashboard client block in `files/realm/remote/infra-realm.yaml` references six `$(JUICEFS_DASHBOARD_*)` tokens that config-cli has to resolve from envFrom. Five of them (URL/origin keys) come from the chart-rendered `client-config` ConfigMap and fall back to chart-default placeholders (`http://juicefs-dashboard.local`). The sixth — `JUICEFS_DASHBOARD_CLIENT_SECRET` — must come from each env's pre-provisioned `keycloak-client-secret`. Envs that never had a juicefs-dashboard (chorus-dev) never had that secret key, so config-cli fails the **entire** infra-realm import.

`chorus-int`, `ebrains-dev`, and `ebrains-qa` all already have:
- `JUICEFS_DASHBOARD_CLIENT_SECRET` in their `keycloak-client-secret`
- a `client.juicefs-dashboard:` block in their env `keycloakx/values.yaml`

so they succeed. chorus-dev never did.

## What

Make the juicefs-dashboard client opt-in, gated on `hasKey .Values.client "juicefs-dashboard"`. Four file changes + chart bump.

### `templates/client-config.yaml`

Wrap the 5 `JUICEFS_DASHBOARD_*` env keys in a `hasKey` gate. When the env doesn't declare the client, the keys are skipped — no phantom `.local` placeholders in the rendered ConfigMap.

### `templates/realm-config.yaml`

Pipe `remote/*-realm.yaml` through `tpl` so the realm payload can use Helm conditionals. The `build/` branch is unchanged — `chorus-build` doesn't have juicefs and we don't want to touch its render. Realm files contain zero `{{` characters today, so `tpl` is a no-op on the existing content.

### `files/realm/remote/infra-realm.yaml`

Wrap the 33-line juicefs-dashboard client block in the same `hasKey` gate.

### `values.yaml`

Remove the chart-level placeholder `juicefs-dashboard:` block. Without this, chart defaults merge **under** env overrides and `hasKey` would always evaluate true — defeating the gate. Replaced with a comment explaining the opt-in contract.

### `Chart.yaml`

`0.0.2 → 0.0.3`.

## Backward compatibility

Verified with `helm template` diff against all four affected envs:

| env | declares `client.juicefs-dashboard` | render delta vs 0.0.2 |
|---|---|---|
| chorus-int | yes | only the `helm.sh/chart` label changes (`0.0.2 → 0.0.3`). Byte-identical otherwise. |
| ebrains-dev | yes | same — label only. |
| ebrains-qa | yes | same — label only. |
| chorus-dev | no | 5 `JUICEFS_DASHBOARD_*` keys removed from client-config ConfigMap; 33-line juicefs-dashboard client block removed from infra-realm payload; everything else unchanged. |

So no re-import in Keycloak for the three opt-in envs, no DB churn, no client-secret rotation. They can stay on 0.0.2 indefinitely, or pick up 0.0.3 opportunistically — either way their behavior is unchanged.

`chorus-build` uses the `build/` realm branch which we didn't touch — unaffected.

## Rollout

1. Merge this PR → CI publishes `keycloakx:0.0.3` to harbor.
2. Bump `chorus-dev/keycloakx/config.json` `version: 0.0.2 → 0.0.3` in the environnements repo (companion PR).
3. Argo syncs chorus-dev → config-cli PostSync runs cleanly.

## Verification (already done locally)

```sh
# chorus-dev: must have zero juicefs references after the change
helm template kx-chorus-dev charts/keycloakx -n keycloak \
  -f environnements/chorus-dev/keycloakx/values.yaml | grep -i juicefs
# → empty

# chorus-int / ebrains-dev / ebrains-qa: must diff cleanly to the chart label only
for env in chorus-int ebrains-dev ebrains-qa; do
  diff <(helm template kx-$env charts/keycloakx@0.0.2 ...) \
       <(helm template kx-$env charts/keycloakx@0.0.3 ...)
done
# → only `helm.sh/chart: keycloakx-0.0.2/3` lines differ
```