### PR TITLE
feat(cert-manager): default both issuers off, bump upstream to v1.20.2 (0.0.19)

### DIFF
--- a/charts/cert-manager/Chart.lock
+++ b/charts/cert-manager/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cert-manager
   repository: oci://quay.io/jetstack/charts
-  version: v1.20.0
-digest: sha256:abc51f826b5a1050abe24430bf8801abf68174e7f8983fb30a512456edd1cf79
-generated: "2026-03-27T11:55:50.640265457Z"
+  version: v1.20.2
+digest: sha256:9a5ee0de189d2c08f867194829020c540f3af2577e25e55f2f68bb7fabd8ba72
+generated: "2026-05-11T16:55:40.344429+02:00"

--- a/charts/cert-manager/Chart.yaml
+++ b/charts/cert-manager/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v2
 description: A Helm chart for cert-manager
 name: cert-manager
-version: 0.0.18
+version: 0.0.19
 dependencies:
   - name: cert-manager
-    version: v1.20.0
+    version: v1.20.2
     repository: oci://quay.io/jetstack/charts
 
 maintainers:

--- a/charts/cert-manager/values.yaml
+++ b/charts/cert-manager/values.yaml
@@ -14,8 +14,9 @@ clusterissuer:
   # MUST be overridden in environment values to a real address for Let's Encrypt registration.
   email: no-reply@example.com
 
+  # Both issuers default to disabled — opt in per-env to whichever the cluster needs.
   http01:
-    enabled: true
+    enabled: false
     # By default the production environment is used.
     # server: https://acme-staging-v02.api.letsencrypt.org/directory
     name: letsencrypt-prod


### PR DESCRIPTION
## Default both ClusterIssuers off, bump cert-manager to v1.20.2

Flips the chart so neither `http01` nor `dns01` ClusterIssuer is rendered by default — each env opts in only to the issuer the cluster actually needs. Also bumps the upstream dependency to the latest patch.

### Changes

- `charts/cert-manager/values.yaml`
  - `clusterissuer.http01.enabled: true → false`. `dns01` was already disabled by default; both are now symmetric and opt-in.
  - One-line comment above the block stating both default off.
- `charts/cert-manager/Chart.yaml`
  - Chart `0.0.18 → 0.0.19`.
  - Upstream `cert-manager` subchart `v1.20.0 → v1.20.2` (cert-manager v1.20.1 + v1.20.2 are values-key compatible; v1.20.2 only fixes invalid YAML when `webhook.config` and `webhook.volumes` are both set, which we don't combine).

### Effects on environments

- `helm template charts/cert-manager/` with no overrides renders 0 ClusterIssuer resources (was 1 with the old `http01.enabled: true` default).
- Lint passes; the three standard cert-manager Deployments still render.

Companion env PR will pin all five active envs to `0.0.19`, drop their now-redundant `http01.enabled: false` overrides, and clean up the `ACMEHTTP01IngressPathTypeExact` feature gate where it's no longer needed.