### PR TITLE
feat(charts): defense-in-depth NetworkPolicy for OIDC-protected services

### DIFF
--- a/charts/chorus-gateway/Chart.yaml
+++ b/charts/chorus-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: chorus-gateway
 description: Envoy Gateway routes and SecurityPolicies for CHORUS services
-version: 0.0.19
+version: 0.0.20
 maintainers:
   - name: iDmple
     email: nathalie.casati@chuv.ch

--- a/charts/chorus-gateway/values.yaml
+++ b/charts/chorus-gateway/values.yaml
@@ -114,6 +114,11 @@ internalAccessDeniedHTML: |-
 #     # discovers them from the issuer's /.well-known/openid-configuration by
 #     # default. Set them explicitly only to override that discovery.
 #     # Set `enabled: false` to temporarily turn off OIDC without deleting the block.
+#     #
+#     # Defense-in-depth: native OIDC enforces auth only at the gateway. Without
+#     # a NetworkPolicy on the upstream, any cluster pod can reach its ClusterIP
+#     # directly and bypass OIDC. juicefs-csi-driver and kube-prometheus-stack
+#     # wrappers ship one — mirror that pattern for new OIDC routes.
 #     - name: juicefs-dashboard
 #       hostname: juicefs-dashboard.chorus-tre.local
 #       namespace: kube-system

--- a/charts/juicefs-csi-driver/Chart.yaml
+++ b/charts/juicefs-csi-driver/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: juicefs-csi-driver
 description: A Helm chart for JuiceFS CSI Driver.
-version: 0.0.16
+version: 0.0.17
 dependencies:
   - name: juicefs-csi-driver
     version: 0.31.1

--- a/charts/juicefs-csi-driver/templates/networkpolicy.yaml
+++ b/charts/juicefs-csi-driver/templates/networkpolicy.yaml
@@ -1,3 +1,6 @@
+# Defense-in-depth: if basic-auth is disabled (e.g. when gateway OIDC is the
+# auth mechanism), any cluster pod could otherwise reach :8088 directly and
+# bypass gateway-side auth.
 {{- if (index .Values "juicefs-csi-driver" "dashboard" "enabled") }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -6,7 +6,7 @@ maintainers:
   - name: floriansipp
     email: florian.sipp@chuv.ch
 name: kube-prometheus-stack
-version: 0.0.35
+version: 0.0.36
 dependencies:
   - name: kube-prometheus-stack
     version: 77.12.0

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -16,6 +16,20 @@ kube-prometheus-stack:
           hosts:
             - alertmanager.build.chorus-tre.local
 
+    # Defense-in-depth: auth is enforced only at the gateway (Envoy OIDC). Without
+    # this NetworkPolicy any cluster pod could reach :9093 directly and bypass it.
+    # Assumes replicas: 1 (no cluster mesh on port 9094).
+    networkPolicy:
+      enabled: true
+      policyTypes:
+        - Ingress
+      gateway:
+        namespace: envoy-gateway-system
+        podLabels:
+          app.kubernetes.io/managed-by: envoy-gateway
+      monitoringRules:
+        prometheus: true  # Prometheus pushes alerts here.
+
     alertmanagerSpec:
       priorityClassName: high-priority
       logFormat: json
@@ -124,6 +138,32 @@ kube-prometheus-stack:
         - secretName: prometheus-general-tls
           hosts:
             - prometheus.build.chorus-tre.local
+
+    # Defense-in-depth: auth is enforced only at the gateway (Envoy OIDC). Without
+    # this NetworkPolicy any cluster pod could reach :9090 directly and bypass it.
+    # Egress is explicit because the upstream template hardcodes
+    # policyTypes: [Egress, Ingress] — Prometheus scrapes targets cluster-wide.
+    networkPolicy:
+      enabled: true
+      flavor: kubernetes
+      egress:
+        - {}  # Allow all egress (scrape targets are anywhere in the cluster).
+      ingress:
+        - from:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: envoy-gateway-system
+              podSelector:
+                matchLabels:
+                  app.kubernetes.io/managed-by: envoy-gateway
+          ports:
+            - port: 9090
+              protocol: TCP
+        - from:
+            - podSelector: {}  # Same-namespace pods (Grafana queries, Prometheus self-scrape).
+          ports:
+            - port: 9090
+              protocol: TCP
 
     prometheusSpec:
       priorityClassName: high-priority


### PR DESCRIPTION
## Defense-in-depth NetworkPolicy for gateway-OIDC services

Native Envoy OIDC enforces authentication only on traffic that arrives via the gateway. Without a NetworkPolicy on the upstream service, any cluster pod can reach its ClusterIP directly and bypass the gateway's auth. This adds (or hardens) NetworkPolicies on the three OIDC-protected services already deployed in our wrappers, and documents the pattern so future OIDC-protected routes get the same treatment.

### Changes

- `charts/kube-prometheus-stack` (0.0.35 → 0.0.36)
  - `prometheus.networkPolicy.enabled: true` by default. Ingress allowed only from `envoy-gateway-system` (gateway pods) and same-namespace pods (Grafana queries, self-scrape). Egress is explicit (allow-all) because the upstream template hardcodes `policyTypes: [Egress, Ingress]` and Prometheus scrapes targets cluster-wide.
  - `alertmanager.networkPolicy.enabled: true` by default. Ingress allowed from `envoy-gateway-system` and from Prometheus pods (for alert firing). Assumes `replicas: 1` — multi-replica deployments would also need port 9094 mesh rules.

- `charts/juicefs-csi-driver` (0.0.16 → 0.0.17)
  - Comment-only change. The existing wrapper-shipped NetworkPolicy already restricts ingress to `envoy-gateway-system` and is gated on `dashboard.enabled` (so it cannot be silently dropped while keeping the dashboard). Added a short defense-in-depth rationale at the top of the template.

- `charts/chorus-gateway` (0.0.19 → 0.0.20)
  - Comment-only change. Added a short defense-in-depth note next to the OIDC example in `values.yaml` so anyone adding a new OIDC-protected route understands the chart-level NetworkPolicy requirement.

### Effects

- `helm template charts/kube-prometheus-stack/` with no overrides now renders two extra `NetworkPolicy` resources (prometheus, alertmanager).
- `helm template charts/juicefs-csi-driver/` output is unchanged from 0.0.16.
- Lint passes on all three charts.

### Pairing

Companion env PR https://github.com/CHORUS-TRE/environments/pull/1703 will pin all 5 active envs to the new chart versions.