### PR TITLE
fix(kube-prometheus-stack): allow Prometheus to scrape alertmanager config-reloader on port 8080

### DIFF
--- a/charts/kube-prometheus-stack/Chart.yaml
+++ b/charts/kube-prometheus-stack/Chart.yaml
@@ -6,7 +6,7 @@ maintainers:
   - name: floriansipp
     email: florian.sipp@chuv.ch
 name: kube-prometheus-stack
-version: 0.0.36
+version: 0.0.37
 dependencies:
   - name: kube-prometheus-stack
     version: 77.12.0

--- a/charts/kube-prometheus-stack/values.yaml
+++ b/charts/kube-prometheus-stack/values.yaml
@@ -29,6 +29,17 @@ kube-prometheus-stack:
           app.kubernetes.io/managed-by: envoy-gateway
       monitoringRules:
         prometheus: true  # Prometheus pushes alerts here.
+      # Allow Prometheus to scrape the config-reloader sidecar metrics on port
+      # 8080 (the alertmanager Service exposes both 9093 and 8080, and the
+      # chart's monitoringRules.prometheus rule only covers 9093).
+      additionalIngress:
+        - from:
+            - podSelector:
+                matchLabels:
+                  app.kubernetes.io/name: prometheus
+          ports:
+            - port: 8080
+              protocol: TCP
 
     alertmanagerSpec:
       priorityClassName: high-priority


### PR DESCRIPTION
## Allow Prometheus to scrape alertmanager config-reloader

After PR #727 enabled `alertmanager.networkPolicy.enabled` by default with `monitoringRules.prometheus: true`, the rendered NetworkPolicy only opens port 9093 (the chart's hard-coded `alertmanager.service.port`) from Prometheus pods. The alertmanager pod also exposes a `config-reloader` sidecar on port 8080 which the chart's ServiceMonitor scrapes — that scrape is now blocked, `up{...config-reloader} == 0`, and `AlertmanagerClusterDown` fires.

### Fix

Adds an `additionalIngress` rule allowing Prometheus pods to reach port 8080 on alertmanager pods. The existing chart rule that allows port 8080 from `alertmanager` pods with `component: config-reloader` is for the alertmanager → alertmanager mesh case (HA replica peer reload notifications); Prometheus's scrape source isn't covered by it.

### Chart bump

`kube-prometheus-stack` `0.0.36 → 0.0.37`.