### PR TITLE
feat(gateway-helm): expose envoyService annotations passthrough (0.0.11)

### DIFF
--- a/charts/gateway-helm/Chart.yaml
+++ b/charts/gateway-helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: The Helm chart for Envoy Gateway
 name: gateway-helm
-version: 0.0.10
+version: 0.0.11
 dependencies:
   - name: gateway-helm
     version: v1.7.1

--- a/charts/gateway-helm/templates/envoyproxy.yaml
+++ b/charts/gateway-helm/templates/envoyproxy.yaml
@@ -15,3 +15,7 @@ spec:
         # filter at the LB level would incorrectly block workspace pods.
         # Pod CIDR restriction is enforced at the application layer via SecurityPolicy.
         externalTrafficPolicy: Local
+        {{- with .Values.envoyServiceAnnotations }}
+        annotations:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}

--- a/charts/gateway-helm/values.yaml
+++ b/charts/gateway-helm/values.yaml
@@ -42,3 +42,10 @@ listeners: []
 # tcpListeners:
 #   - port: 22
 tcpListeners: []
+
+# Extra annotations for the auto-created Envoy LoadBalancer Service
+# (EnvoyProxy spec.provider.kubernetes.envoyService.annotations). Use this to pass
+# load-balancer-implementation-specific Service annotations (e.g. health-check
+# tuning) when the underlying LB needs them. Leave empty when not required.
+# Set concrete values per environment.
+envoyServiceAnnotations: {}


### PR DESCRIPTION
## Expose EnvoyProxy envoyService annotations

Adds an optional `envoyServiceAnnotations` value, rendered into the `EnvoyProxy` `spec.provider.kubernetes.envoyService.annotations`. This lets consumers pass load-balancer-implementation-specific Service annotations (e.g. health-check tuning) when the underlying LB requires them, without changing the chart per environment.

### Changes

- `templates/envoyproxy.yaml`: render `annotations:` under `envoyService` from `.Values.envoyServiceAnnotations`, only when non-empty (`{{- with }}` guard — no key emitted by default, behaviour unchanged for existing consumers).
- `values.yaml`: document the new `envoyServiceAnnotations` key, default `{}`.
- `Chart.yaml`: `0.0.10 → 0.0.11`.

### Rendering

- Default (`{}`) → no `annotations` key on the EnvoyProxy (no behaviour change).
- Set → annotations applied to the auto-created LoadBalancer Service.

`helm lint` clean; `helm template` verified for both the empty default and a populated map.