### PR TITLE
feat(chorus-gateway): support per-route HTTPRoute timeouts

### DIFF
--- a/charts/chorus-gateway/Chart.yaml
+++ b/charts/chorus-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: chorus-gateway
 description: Envoy Gateway routes and SecurityPolicies for CHORUS services
-version: 0.0.20
+version: 0.0.21
 maintainers:
   - name: iDmple
     email: nathalie.casati@chuv.ch

--- a/charts/chorus-gateway/templates/_helpers.tpl
+++ b/charts/chorus-gateway/templates/_helpers.tpl
@@ -45,6 +45,17 @@ Argument: a route map with redirectPath.
 {{- end }}
 
 {{/*
+HTTPRoute spec.rules[].timeouts fragment. Caller is responsible for the
+conditional wrap (typically `{{- with .timeouts }}` around an `include` of
+this helper), mirroring the `chorus-gateway.redirectOnRoot` pattern.
+Argument: a timeouts map (Gateway API HTTPRoute timeouts).
+*/}}
+{{- define "chorus-gateway.routeTimeouts" -}}
+timeouts:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+
+{{/*
 SecurityPolicy authorization rule scoped to the cluster pod CIDR.
 Argument: dict with keys `name` (rule name), `action` ("Allow" or "Deny"),
 `podCIDR` (the cluster pod CIDR as a string).

--- a/charts/chorus-gateway/templates/httproutes.yaml
+++ b/charts/chorus-gateway/templates/httproutes.yaml
@@ -29,10 +29,18 @@ spec:
             value: {{ required "pathPrefix is required" .pathPrefix | quote }}
       backendRefs:
         {{- include "chorus-gateway.backendRef" $route | nindent 8 }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
     {{- else }}
     - backendRefs:
         {{- include "chorus-gateway.backendRef" . | nindent 8 }}
+      {{- with .timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 
@@ -69,10 +77,18 @@ spec:
             value: {{ required "pathPrefix is required" .pathPrefix | quote }}
       backendRefs:
         {{- include "chorus-gateway.backendRef" $route | nindent 8 }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
     {{- else }}
     - backendRefs:
         {{- include "chorus-gateway.backendRef" . | nindent 8 }}
+      {{- with .timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}
 
@@ -141,9 +157,17 @@ spec:
             value: {{ required "pathPrefix is required" .pathPrefix | quote }}
       backendRefs:
         {{- include "chorus-gateway.backendRef" $route | nindent 8 }}
+      {{- with $route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
     {{- else }}
     - backendRefs:
         {{- include "chorus-gateway.backendRef" . | nindent 8 }}
+      {{- with .timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/chorus-gateway/templates/httproutes.yaml
+++ b/charts/chorus-gateway/templates/httproutes.yaml
@@ -30,16 +30,14 @@ spec:
       backendRefs:
         {{- include "chorus-gateway.backendRef" $route | nindent 8 }}
       {{- with $route.timeouts }}
-      timeouts:
-        {{- toYaml . | nindent 8 }}
+      {{- include "chorus-gateway.routeTimeouts" . | nindent 6 }}
       {{- end }}
     {{- end }}
     {{- else }}
     - backendRefs:
         {{- include "chorus-gateway.backendRef" . | nindent 8 }}
       {{- with .timeouts }}
-      timeouts:
-        {{- toYaml . | nindent 8 }}
+      {{- include "chorus-gateway.routeTimeouts" . | nindent 6 }}
       {{- end }}
     {{- end }}
 {{- end }}
@@ -78,16 +76,14 @@ spec:
       backendRefs:
         {{- include "chorus-gateway.backendRef" $route | nindent 8 }}
       {{- with $route.timeouts }}
-      timeouts:
-        {{- toYaml . | nindent 8 }}
+      {{- include "chorus-gateway.routeTimeouts" . | nindent 6 }}
       {{- end }}
     {{- end }}
     {{- else }}
     - backendRefs:
         {{- include "chorus-gateway.backendRef" . | nindent 8 }}
       {{- with .timeouts }}
-      timeouts:
-        {{- toYaml . | nindent 8 }}
+      {{- include "chorus-gateway.routeTimeouts" . | nindent 6 }}
       {{- end }}
     {{- end }}
 {{- end }}
@@ -158,16 +154,14 @@ spec:
       backendRefs:
         {{- include "chorus-gateway.backendRef" $route | nindent 8 }}
       {{- with $route.timeouts }}
-      timeouts:
-        {{- toYaml . | nindent 8 }}
+      {{- include "chorus-gateway.routeTimeouts" . | nindent 6 }}
       {{- end }}
     {{- end }}
     {{- else }}
     - backendRefs:
         {{- include "chorus-gateway.backendRef" . | nindent 8 }}
       {{- with .timeouts }}
-      timeouts:
-        {{- toYaml . | nindent 8 }}
+      {{- include "chorus-gateway.routeTimeouts" . | nindent 6 }}
       {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/chorus-gateway/values.yaml
+++ b/charts/chorus-gateway/values.yaml
@@ -19,6 +19,7 @@ gateway:
 # Must be set in environment values.
 #
 # Optional: matches (path-restricted route, e.g. expose only /openid-connect/ internally).
+# Optional: timeouts (Gateway API HTTPRoute timeouts; see openRoutes for an example).
 #
 # Example:
 #   internalRoutes:
@@ -72,6 +73,7 @@ internalAccessDeniedHTML: |-
 #
 # Optional: matches (path-restricted, e.g. restrict only /admin on a hostname
 # that is otherwise served by an openRoute catch-all).
+# Optional: timeouts (Gateway API HTTPRoute timeouts; see openRoutes for an example).
 #
 # Example:
 #   externalRoutes:
@@ -144,6 +146,12 @@ externalRoutes: []
 #
 # Optional: matches (path-restricted, e.g. only /v2 and /service/token open
 # on a hostname that is otherwise served by an externalRoute catchall).
+# Optional: timeouts — Gateway API HTTPRoute timeouts. Both `request` and
+# `backendRequest` accept Go duration strings (e.g. "30s", "5m") or "0s" to
+# disable the wall-clock kill. When disabled, envoy's per-stream idle timeout
+# (default 5m, resets per byte) still protects against stalled streams. Use
+# this for endpoints that legitimately stream large bodies, e.g. a container
+# registry serving multi-GB image layers.
 #
 # Example:
 #   openRoutes:
@@ -154,6 +162,8 @@ externalRoutes: []
 #       servicePort: 80
 #     # Expose only /v2 and /service/token on a hostname otherwise served by
 #     # an externalRoute catchall (so pods can pull images, browsers get the UI).
+#     # timeouts.request "0s" disables the envoy 15s default so multi-GB image
+#     # layers can stream end-to-end; per-stream idle timeout still protects.
 #     - name: harbor-registry
 #       hostname: harbor.chorus-tre.local
 #       namespace: harbor
@@ -162,6 +172,9 @@ externalRoutes: []
 #       matches:
 #         - pathPrefix: /v2
 #         - pathPrefix: /service/token
+#       timeouts:
+#         request: "0s"
+#         backendRequest: "0s"
 #     # OIDC on an openRoute — for Build cluster, where CHORUS isn't deployed.
 #     # Envoy Gateway runs the full Keycloak login flow before any request reaches
 #     # prometheus. No podCIDR rule is emitted (no workspaces to isolate).


### PR DESCRIPTION
## Support per-route HTTPRoute timeouts on chorus-gateway

Adds an optional `timeouts:` field on each route entry, threading through to the rendered HTTPRoute's `spec.rules[].timeouts`. Lets a route disable envoy gateway's 15-second default `route.timeout`, which otherwise kills any response stream that takes longer than that — for example, a container registry serving multi-GB image layers.

### Changes

- `chorus-gateway` (0.0.20 → 0.0.21)
  - `templates/httproutes.yaml`: render optional `spec.rules[].timeouts` from each route entry on all three route types (internalRoutes, externalRoutes, openRoutes), in both the path-matched and catchall paths.
  - `values.yaml`: document the new optional field on each route block; example added under `openRoutes` showing a registry use case (`request: "0s"` + per-stream idle timeout still protects against stalled streams).

### Effects

- Routes that omit `timeouts:` render byte-identical HTTPRoutes to 0.0.20 (`{{- with }}` is a no-op when absent).
- Routes that opt in render `spec.rules[].timeouts: { request: <dur>, backendRequest: <dur> }`.
- No SecurityPolicy / ReferenceGrant changes; only the HTTPRoute template changes.

### Versions

- chorus-gateway 0.0.20 → 0.0.21