### PR TITLE
feat(chorus-gateway): add extraAllowedCIDRs per-route source-IP allowlist (0.0.22)

### DIFF
--- a/charts/chorus-gateway/Chart.yaml
+++ b/charts/chorus-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: chorus-gateway
 description: Envoy Gateway routes and SecurityPolicies for CHORUS services
-version: 0.0.21
+version: 0.0.22
 maintainers:
   - name: iDmple
     email: nathalie.casati@chuv.ch

--- a/charts/chorus-gateway/templates/_helpers.tpl
+++ b/charts/chorus-gateway/templates/_helpers.tpl
@@ -56,26 +56,14 @@ timeouts:
 {{- end }}
 
 {{/*
-SecurityPolicy authorization rule scoped to the cluster pod CIDR.
-Argument: dict with keys `name` (rule name), `action` ("Allow" or "Deny"),
-`podCIDR` (the cluster pod CIDR as a string).
-*/}}
-{{- define "chorus-gateway.podCIDRRule" -}}
-- name: {{ .name }}
-  action: {{ .action }}
-  principal:
-    clientCIDRs:
-      - {{ required "podCIDR must be set to match the cluster's pod CIDR" .podCIDR | quote }}
-{{- end }}
-
-{{/*
-SecurityPolicy authorization rule for a list of CIDRs. Generalises
-podCIDRRule for the per-route case where podCIDR is augmented with the
-route's `extraAllowedCIDRs`.
+SecurityPolicy authorization rule for a list of CIDRs. Used for both the
+common "Allow/Deny podCIDR only" case (`cidrs: (list .Values.podCIDR)`) and
+the per-route case where podCIDR is augmented with `extraAllowedCIDRs`.
 Argument: dict with keys `name` (rule name), `action` ("Allow" or "Deny"),
 `cidrs` (list of CIDR strings, must be non-empty).
 */}}
 {{- define "chorus-gateway.cidrRule" -}}
+{{- if not .cidrs }}{{ fail "chorus-gateway.cidrRule: cidrs must be a non-empty list" }}{{ end -}}
 - name: {{ .name }}
   action: {{ .action }}
   principal:

--- a/charts/chorus-gateway/templates/_helpers.tpl
+++ b/charts/chorus-gateway/templates/_helpers.tpl
@@ -69,6 +69,23 @@ Argument: dict with keys `name` (rule name), `action` ("Allow" or "Deny"),
 {{- end }}
 
 {{/*
+SecurityPolicy authorization rule that allows a list of CIDRs.
+Generalises podCIDRRule for the per-route case where podCIDR is augmented
+with extra source CIDRs (Part 12 `extraAllowedCIDRs` feature).
+Argument: dict with keys `name` (rule name), `action` ("Allow" or "Deny"),
+`cidrs` (list of CIDR strings, must be non-empty).
+*/}}
+{{- define "chorus-gateway.cidrAllowRule" -}}
+- name: {{ .name }}
+  action: {{ .action }}
+  principal:
+    clientCIDRs:
+      {{- range .cidrs }}
+      - {{ . | quote }}
+      {{- end }}
+{{- end }}
+
+{{/*
 Route-name helpers — centralize the naming convention so renaming a suffix
 is a one-line change in _helpers.tpl rather than chasing strings across
 multiple templates. All take a route map and return "<route.name>-<suffix>".
@@ -99,6 +116,10 @@ multiple templates. All take a route map and return "<route.name>-<suffix>".
 
 {{- define "chorus-gateway.extAuthSecurityPolicyName" -}}
 {{- printf "%s-extauth-securitypolicy" (required "name is required" .name) -}}
+{{- end }}
+
+{{- define "chorus-gateway.internalCIDRSecurityPolicyName" -}}
+{{- printf "%s-internal-securitypolicy" (required "name is required" .name) -}}
 {{- end }}
 
 {{- define "chorus-gateway.externalOIDCSecurityPolicyName" -}}

--- a/charts/chorus-gateway/templates/_helpers.tpl
+++ b/charts/chorus-gateway/templates/_helpers.tpl
@@ -69,13 +69,13 @@ Argument: dict with keys `name` (rule name), `action` ("Allow" or "Deny"),
 {{- end }}
 
 {{/*
-SecurityPolicy authorization rule that allows a list of CIDRs.
-Generalises podCIDRRule for the per-route case where podCIDR is augmented
-with extra source CIDRs (Part 12 `extraAllowedCIDRs` feature).
+SecurityPolicy authorization rule for a list of CIDRs. Generalises
+podCIDRRule for the per-route case where podCIDR is augmented with the
+route's `extraAllowedCIDRs`.
 Argument: dict with keys `name` (rule name), `action` ("Allow" or "Deny"),
 `cidrs` (list of CIDR strings, must be non-empty).
 */}}
-{{- define "chorus-gateway.cidrAllowRule" -}}
+{{- define "chorus-gateway.cidrRule" -}}
 - name: {{ .name }}
   action: {{ .action }}
   principal:

--- a/charts/chorus-gateway/templates/oidcsecuritypolicy.yaml
+++ b/charts/chorus-gateway/templates/oidcsecuritypolicy.yaml
@@ -59,7 +59,7 @@ spec:
   authorization:
     defaultAction: Allow
     rules:
-      {{- include "chorus-gateway.podCIDRRule" (dict "name" "deny-workspace-pods" "action" "Deny" "podCIDR" $.Values.podCIDR) | nindent 6 }}
+      {{- include "chorus-gateway.cidrRule" (dict "name" "deny-workspace-pods" "action" "Deny" "cidrs" (list (required "podCIDR must be set to match the cluster's pod CIDR" $.Values.podCIDR))) | nindent 6 }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/chorus-gateway/templates/securitypolicy.yaml
+++ b/charts/chorus-gateway/templates/securitypolicy.yaml
@@ -2,8 +2,19 @@
   Internal SecurityPolicy — allows podCIDR only (workspace pods).
   External clients are rejected (403 for HTTP routes, L4 connection close for TCP routes).
   Targets internal HTTPRoutes and TCPRoutes.
+
+  Routes that set `extraAllowedCIDRs` are EXCLUDED from this shared policy; each
+  such route gets its own per-route SecurityPolicy further below (podCIDR plus
+  the route's extra source CIDRs). Envoy Gateway forbids two SecurityPolicies
+  targeting the same HTTPRoute, so each route must be targeted by exactly one.
 */}}
-{{- if or .Values.internalRoutes .Values.internalTcpRoutes }}
+{{- $sharedInternalRoutes := list -}}
+{{- range .Values.internalRoutes }}
+{{- if not .extraAllowedCIDRs }}
+{{- $sharedInternalRoutes = append $sharedInternalRoutes . }}
+{{- end }}
+{{- end }}
+{{- if or $sharedInternalRoutes .Values.internalTcpRoutes }}
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
@@ -14,7 +25,7 @@ metadata:
     {{- include "chorus-gateway.labels" . | nindent 4 }}
 spec:
   targetRefs:
-    {{- range .Values.internalRoutes }}
+    {{- range $sharedInternalRoutes }}
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
       name: {{ include "chorus-gateway.internalHTTPRouteName" . }}
@@ -28,6 +39,34 @@ spec:
     defaultAction: Deny
     rules:
       {{- include "chorus-gateway.podCIDRRule" (dict "name" "allow-workspace-pods" "action" "Allow" "podCIDR" .Values.podCIDR) | nindent 6 }}
+{{- end }}
+
+{{- /*
+  Per-route internal SecurityPolicies for routes that need additional source
+  CIDRs on top of podCIDR (e.g. an off-cluster service reaching an internal
+  endpoint). One SecurityPolicy per route to avoid expanding the allowlist of
+  unrelated internal routes.
+*/}}
+{{- range .Values.internalRoutes }}
+{{- if .extraAllowedCIDRs }}
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: {{ include "chorus-gateway.internalCIDRSecurityPolicyName" . }}
+  namespace: {{ $.Values.gateway.namespace }}
+  labels:
+    {{- include "chorus-gateway.labels" $ | nindent 4 }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: {{ include "chorus-gateway.internalHTTPRouteName" . }}
+  authorization:
+    defaultAction: Deny
+    rules:
+      {{- include "chorus-gateway.cidrAllowRule" (dict "name" "allow-workspace-pods-and-extra" "action" "Allow" "cidrs" (prepend .extraAllowedCIDRs (required "podCIDR must be set" $.Values.podCIDR))) | nindent 6 }}
+{{- end }}
 {{- end }}
 
 {{- /*

--- a/charts/chorus-gateway/templates/securitypolicy.yaml
+++ b/charts/chorus-gateway/templates/securitypolicy.yaml
@@ -38,7 +38,7 @@ spec:
   authorization:
     defaultAction: Deny
     rules:
-      {{- include "chorus-gateway.podCIDRRule" (dict "name" "allow-workspace-pods" "action" "Allow" "podCIDR" .Values.podCIDR) | nindent 6 }}
+      {{- include "chorus-gateway.cidrRule" (dict "name" "allow-workspace-pods" "action" "Allow" "cidrs" (list (required "podCIDR must be set to match the cluster's pod CIDR" .Values.podCIDR))) | nindent 6 }}
 {{- end }}
 
 {{- /*
@@ -101,7 +101,7 @@ spec:
   authorization:
     defaultAction: Allow
     rules:
-      {{- include "chorus-gateway.podCIDRRule" (dict "name" "deny-workspace-pods" "action" "Deny" "podCIDR" .Values.podCIDR) | nindent 6 }}
+      {{- include "chorus-gateway.cidrRule" (dict "name" "deny-workspace-pods" "action" "Deny" "cidrs" (list (required "podCIDR must be set to match the cluster's pod CIDR" .Values.podCIDR))) | nindent 6 }}
 {{- end }}
 
 {{- /*
@@ -127,7 +127,7 @@ spec:
   authorization:
     defaultAction: Allow
     rules:
-      {{- include "chorus-gateway.podCIDRRule" (dict "name" "deny-workspace-pods" "action" "Deny" "podCIDR" $.Values.podCIDR) | nindent 6 }}
+      {{- include "chorus-gateway.cidrRule" (dict "name" "deny-workspace-pods" "action" "Deny" "cidrs" (list (required "podCIDR must be set to match the cluster's pod CIDR" $.Values.podCIDR))) | nindent 6 }}
   extAuth:
     failOpen: false
     headersToExtAuth:

--- a/charts/chorus-gateway/templates/securitypolicy.yaml
+++ b/charts/chorus-gateway/templates/securitypolicy.yaml
@@ -65,7 +65,7 @@ spec:
   authorization:
     defaultAction: Deny
     rules:
-      {{- include "chorus-gateway.cidrAllowRule" (dict "name" "allow-workspace-pods-and-extra" "action" "Allow" "cidrs" (prepend .extraAllowedCIDRs (required "podCIDR must be set" $.Values.podCIDR))) | nindent 6 }}
+      {{- include "chorus-gateway.cidrRule" (dict "name" "allow-workspace-pods-and-extra" "action" "Allow" "cidrs" (prepend .extraAllowedCIDRs (required "podCIDR must be set" $.Values.podCIDR))) | nindent 6 }}
 {{- end }}
 {{- end }}
 

--- a/charts/chorus-gateway/values.yaml
+++ b/charts/chorus-gateway/values.yaml
@@ -20,6 +20,28 @@ gateway:
 #
 # Optional: matches (path-restricted route, e.g. expose only /openid-connect/ internally).
 # Optional: timeouts (Gateway API HTTPRoute timeouts; see openRoutes for an example).
+# Optional: extraAllowedCIDRs (list of source CIDRs allowed on this route in
+#   addition to the cluster podCIDR). When set, the route is pulled out of the
+#   shared internal-securitypolicy and given its own dedicated SecurityPolicy
+#   (defaultAction: Deny + Allow rule whose clientCIDRs = [podCIDR] +
+#   extraAllowedCIDRs). Use this for an internal endpoint that also needs to be
+#   reachable from a fixed set of off-cluster source IPs without exposing every
+#   other internal route to those IPs.
+#
+#   Use with caution — each entry widens the allowlist on this route:
+#
+#   - Source IP is the only barrier. The route's own authn/authz must be
+#     sufficient for any caller in the allowlist; the SecurityPolicy does not
+#     authenticate anyone.
+#   - Keep CIDRs as narrow as possible (prefer /32). A /24 is rarely justified.
+#   - Requires externalTrafficPolicy: Local on the Gateway so Envoy sees the
+#     real client IP. With Cluster, the LB SNATs to a node IP and the check is
+#     meaningless.
+#   - Never apply to a route serving an admin UI, an interactive login page, or
+#     anything not designed for a non-workspace caller. Split such surfaces
+#     into a separate internalRoute with a path match (matches:) and allowlist
+#     only the safe paths.
+#   - Source IPs drift; review periodically and remove stale entries.
 #
 # Example:
 #   internalRoutes:
@@ -41,6 +63,12 @@ gateway:
 #       servicePort: 5000
 #       matches:
 #         - pathPrefix: /openid-connect
+#       # Allowed on top of the cluster podCIDR. The values below are the
+#       # RFC 5737 TEST-NET-3 documentation range — replace with real source
+#       # CIDRs in environment values.
+#       extraAllowedCIDRs:
+#         - 198.51.100.10/32
+#         - 198.51.100.11/32
 internalRoutes: []
 
 # HTML body returned when an internal route denies an external client (SecurityPolicy 403).


### PR DESCRIPTION
## Per-route source-IP allowlist for internal routes (`extraAllowedCIDRs`)

Adds an optional `extraAllowedCIDRs` field on internal route entries so a single internal endpoint can be reachable from the cluster pod CIDR PLUS a fixed set of off-cluster source IPs, without expanding the allowlist of every other internal route.

When a route sets `extraAllowedCIDRs`, the chart pulls it out of the shared `internal-securitypolicy` and emits a dedicated per-route SecurityPolicy whose Allow rule lists `[podCIDR] + extraAllowedCIDRs`. Envoy Gateway forbids two SecurityPolicies targeting the same HTTPRoute, so the route ends up targeted by exactly one. Routes without `extraAllowedCIDRs` keep their current behaviour (covered by the shared policy with `Allow podCIDR` only).

### Changes

- `templates/_helpers.tpl`: consolidates the previous `chorus-gateway.podCIDRRule` (single-CIDR rule) into a generic `chorus-gateway.cidrRule` that takes a list of CIDRs and enforces non-empty input via `fail`. New `chorus-gateway.internalCIDRSecurityPolicyName` helper (`<route-name>-internal-securitypolicy`).
- `templates/securitypolicy.yaml` + `templates/oidcsecuritypolicy.yaml`: all four call sites that used `podCIDRRule` now use `cidrRule (list (required "..." .Values.podCIDR))` for the single-CIDR case. The shared `internal-securitypolicy` `targetRefs` loop skips routes that set `extraAllowedCIDRs`; the shared block is guarded so it isn't emitted with empty targetRefs. A new block iterates internal routes with `extraAllowedCIDRs` and emits one SecurityPolicy per route, `defaultAction: Deny` + one Allow rule whose `clientCIDRs` is the cluster podCIDR prepended to the route's `extraAllowedCIDRs`.
- `values.yaml`: documents the new field on the `internalRoutes` example, with a "use with caution" block covering the implications (source-IP-only barrier, requires `externalTrafficPolicy: Local` so Envoy sees the real client IP, never apply to admin/interactive surfaces, periodic review). Example IPs use the RFC 5737 TEST-NET-3 documentation range.
- `Chart.yaml`: 0.0.21 → 0.0.22.

### Compatibility

Backward-compatible. Existing environments that don't set `extraAllowedCIDRs` on any internal route render structurally identical SecurityPolicies (only the `helm.sh/chart` version label changes from `chorus-gateway-0.0.21` to `chorus-gateway-0.0.22`) — the shared `internal-securitypolicy` retains all routes and the new per-route block emits nothing.