### PR TITLE
feat: default valkey cache NetworkPolicy to own-namespace ingress

### DIFF
--- a/charts/valkey/Chart.yaml
+++ b/charts/valkey/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Valkey is an open source (BSD) high-performance key/value datastore that supports a variety workloads such as caching, message queues, and can act as a primary database.
 name: valkey
-version: 0.0.13
+version: 0.0.14
 dependencies:
   - name: valkey
     version: 2.4.7

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -39,21 +39,41 @@ valkey:
     podMonitor:
       enabled: true
 
-  # Default-deny ingress: only pods in the release's own namespace may reach
-  # Redis (6379), and only Prometheus may scrape metrics (9121).
-  # `allowExternal: false` drops the chart's permit-all rule; the empty
-  # podSelector below then admits the whole own namespace without hardcoding
-  # its name. A cache whose consumers live in another namespace overrides
-  # `networkPolicy.extraIngress` to add a namespaceSelector for that namespace.
+  # Default-deny ingress: only pods in the release's own namespace reach Redis
+  # (6379), and only Prometheus scrapes metrics (9121).
+  #
+  # `allowExternal: false` drops the chart's permit-all rule. The empty
+  # podSelector in extraIngress admits the whole own namespace without
+  # hardcoding its name — this is the chart's job, leave it untouched.
+  #
+  # To grant a consumer in ANOTHER namespace, a release sets
+  #   networkPolicy.ingressNSMatchLabels: {kubernetes.io/metadata.name: <ns>}
+  # which appends a namespaceSelector to the built-in 6379 rule additively, so
+  # the own-namespace rule is preserved automatically (no need to restate it).
+  # This admits ONE extra namespace (matchLabels is a single AND-combined set);
+  # for 2+, override extraIngress instead and restate `podSelector: {}` — which
+  # re-introduces the restate-own-ns footgun, so treat it as a rare exception.
+  #
+  # networkPolicy.ingressNSMatchLabels (cache port) and
+  # networkPolicy.metrics.ingressNSMatchLabels are independent — overriding one
+  # leaves the other untouched. Both apply only while the matching allowExternal
+  # is false (the default here).
   networkPolicy:
     enabled: true
     allowExternal: false
     extraIngress:
+      # 6379 is literal and must match primary.containerPorts.valkey (its
+      # default). Don't template it: in a values list the scalar must be quoted,
+      # so it renders as a string, which NetworkPolicy reads as a *named* port
+      # and would match nothing. Update both together if the cache port changes.
       - ports:
           - port: 6379
             protocol: TCP
         from:
           - podSelector: {}
+    # The metrics namespace below assumes Prometheus runs in `prometheus`
+    # (true for current envs); override per-env if yours differs, or metrics
+    # scraping silently stops after a release adopts this default.
     metrics:
       allowExternal: false
       ingressNSMatchLabels:

--- a/charts/valkey/values.yaml
+++ b/charts/valkey/values.yaml
@@ -38,3 +38,23 @@ valkey:
 
     podMonitor:
       enabled: true
+
+  # Default-deny ingress: only pods in the release's own namespace may reach
+  # Redis (6379), and only Prometheus may scrape metrics (9121).
+  # `allowExternal: false` drops the chart's permit-all rule; the empty
+  # podSelector below then admits the whole own namespace without hardcoding
+  # its name. A cache whose consumers live in another namespace overrides
+  # `networkPolicy.extraIngress` to add a namespaceSelector for that namespace.
+  networkPolicy:
+    enabled: true
+    allowExternal: false
+    extraIngress:
+      - ports:
+          - port: 6379
+            protocol: TCP
+        from:
+          - podSelector: {}
+    metrics:
+      allowExternal: false
+      ingressNSMatchLabels:
+        kubernetes.io/metadata.name: prometheus


### PR DESCRIPTION
## Restrict the valkey cache to its own namespace by default

The `valkey` chart shipped with its NetworkPolicy in permit-all mode, so every cache built on it accepted Redis connections from any pod in the cluster. This makes own-namespace ingress the default: a cache now only accepts connections from pods in its own namespace, and metrics scrapes only from Prometheus. Caches whose consumers live in another namespace opt back in explicitly via values.

### Changes

- `charts/valkey` (0.0.13 → 0.0.14)
  - `networkPolicy.allowExternal: false` drops the chart's permit-all ingress rule.
  - `networkPolicy.extraIngress` adds one rule whose `from` is an empty `podSelector: {}` — i.e. all pods in the release's own namespace. An empty selector instead of a `namespaceSelector` keyed on the namespace name keeps the default generic, so no per-release value names the namespace. This own-namespace rule is the chart's job and is never touched per-release.
  - `networkPolicy.metrics` restricts the exporter port (9121) to the `prometheus` namespace. That namespace is a per-env assumption — an environment whose Prometheus runs elsewhere must override it, or metrics scraping silently stops.
  - A release whose consumers run in another namespace sets `networkPolicy.ingressNSMatchLabels: {kubernetes.io/metadata.name: <ns>}`, which appends a `namespaceSelector` to the built-in 6379 rule additively — the own-namespace rule is preserved automatically, so overrides never restate it. This admits a single extra namespace; a cache needing 2+ falls back to overriding `extraIngress` (and restating `podSelector: {}`).

### Effects

- `helm template` of a default release renders a NetworkPolicy whose `6379` ingress admits only the release namespace (empty podSelector) alongside the chart's existing client-label / instance selectors, and whose `9121` ingress admits only the `prometheus` namespace. Previously both ports had an empty `from` (permit-all).
- No change to any running release until its consumer bumps to 0.0.14; releases pinned to 0.0.13 are unaffected.

### Verification

- `helm dependency build` (valkey 2.4.7) + `helm template`: the default render produces own-namespace `6379` ingress + prometheus-only `9121`; a render with `ingressNSMatchLabels` set adds the extra namespace to the built-in rule while the own-namespace `podSelector: {}` rule stays intact.

### Versions

- valkey chart 0.0.13 → 0.0.14

### Cleanups (review responses)

- Cross-namespace overrides use `ingressNSMatchLabels` (own-namespace stays in the chart-default `extraIngress`, never restated) instead of overriding `extraIngress` wholesale.
- Documented that the cache-port and metrics namespace selectors are independent keys, that the `prometheus` metrics namespace is a per-env assumption, and why the own-ns rule's `6379` is kept literal (a templated value renders as a string/named port).
