### PR TITLE
fix(chorus-ci): full clone for CI builds so non-tip commits resolve

### DIFF
--- a/charts/chorus-ci/Chart.yaml
+++ b/charts/chorus-ci/Chart.yaml
@@ -18,4 +18,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.148
+version: 0.0.149

--- a/charts/chorus-ci/templates/build-chorus-backend-sensor.yaml
+++ b/charts/chorus-ci/templates/build-chorus-backend-sensor.yaml
@@ -369,7 +369,6 @@ spec:
                                   passwordSecret:
                                     name: {{ $githubSecretName }}
                                     key: {{ $githubSecretPasswordKey }}
-                                  depth: 1
                                   ref: "{{`{{workflow.parameters.ref}}`}}"
 
           parameters:
@@ -519,7 +518,6 @@ spec:
                                   passwordSecret:
                                     name: {{ $githubSecretName }}
                                     key: {{ $githubSecretPasswordKey }}
-                                  depth: 1
                                   ref: "{{`{{workflow.parameters.ref}}`}}"
 
                       - - name: helm-publish
@@ -549,7 +547,6 @@ spec:
                                   passwordSecret:
                                     name: {{ $githubSecretName }}
                                     key: {{ $githubSecretPasswordKey }}
-                                  depth: 1
                                   ref: "{{`{{workflow.parameters.ref}}`}}"
 
           parameters:

--- a/charts/chorus-ci/templates/build-images-sensor.yaml
+++ b/charts/chorus-ci/templates/build-images-sensor.yaml
@@ -98,7 +98,6 @@ spec:
                             passwordSecret:
                               name: {{ $githubSecretName }}
                               key: {{ $githubSecretPasswordKey }}
-                            depth: 1
                             ref: "{{`{{workflow.parameters.ref}}`}}"
                     script:
                       image: {{ .Values.chorusImages.python.imageDomain | default .Values.global.imageDomain }}/{{ .Values.chorusImages.python.imageNamespace | default .Values.global.imageNamespace }}/python:{{ .Values.chorusImages.python.tag | default "latest" }}
@@ -223,7 +222,6 @@ spec:
                             passwordSecret:
                               name: {{ $githubSecretName }}
                               key: {{ $githubSecretPasswordKey }}
-                            depth: 1
                             ref: "{{`{{workflow.parameters.ref}}`}}"
                     volumes:
                       - name: docker-data

--- a/charts/chorus-ci/templates/build-services-sensor.yaml
+++ b/charts/chorus-ci/templates/build-services-sensor.yaml
@@ -88,7 +88,6 @@ spec:
                                   passwordSecret:
                                     name: {{ $githubSecretName }}
                                     key: {{ $githubSecretPasswordKey }}
-                                  depth: 1
                                   ref: "{{`{{workflow.parameters.ref}}`}}"
                           # This loops over the service names from get-paths
                           withParam: "{{`{{steps.get-paths.outputs.result}}`}}"

--- a/charts/chorus-ci/templates/build-web-ui-sensor.yaml
+++ b/charts/chorus-ci/templates/build-web-ui-sensor.yaml
@@ -266,7 +266,6 @@ spec:
                                   passwordSecret:
                                     name: {{ $githubSecretName }}
                                     key: {{ $githubSecretPasswordKey }}
-                                  depth: 1
                                   ref: "{{`{{workflow.parameters.ref}}`}}"
 
                       - - name: helm-publish
@@ -294,7 +293,6 @@ spec:
                                   passwordSecret:
                                     name: {{ $githubSecretName }}
                                     key: {{ $githubSecretPasswordKey }}
-                                  depth: 1
                                   ref: "{{`{{workflow.parameters.ref}}`}}"
 
           parameters:

--- a/charts/chorus-ci/templates/build-workbench-operator-sensor.yaml
+++ b/charts/chorus-ci/templates/build-workbench-operator-sensor.yaml
@@ -504,7 +504,6 @@ spec:
                                   passwordSecret:
                                     name: {{ $githubSecretName }}
                                     key: {{ $githubSecretPasswordKey }}
-                                  depth: 1
                                   ref: "{{`{{workflow.parameters.ref}}`}}"
 
                       - - name: helm-publish
@@ -532,7 +531,6 @@ spec:
                                   passwordSecret:
                                     name: {{ $githubSecretName }}
                                     key: {{ $githubSecretPasswordKey }}
-                                  depth: 1
                                   ref: "{{`{{workflow.parameters.ref}}`}}"
 
           parameters:

--- a/charts/chorus-ci/templates/chorus-backend-ci-workflow-template.yaml
+++ b/charts/chorus-ci/templates/chorus-backend-ci-workflow-template.yaml
@@ -137,7 +137,6 @@ spec:
                     passwordSecret:
                       name: {{ $githubSecretName }}
                       key: {{ $githubSecretPasswordKey }}
-                    depth: 1
                     ref: "{{`{{workflow.parameters.ref}}`}}"
         - - name: backend-acceptance-tests
             templateRef:
@@ -179,5 +178,4 @@ spec:
                     passwordSecret:
                       name: {{ $githubSecretName }}
                       key: {{ $githubSecretPasswordKey }}
-                    depth: 1
                     ref: "{{`{{workflow.parameters.ref}}`}}"


### PR DESCRIPTION
## CI builds fail when their pinned commit is no longer the branch tip

The chorus-ci sensors check out the source repo as a **shallow git artifact** (`depth: 1`) pinned to the pushed commit SHA. A shallow clone only fetches the current branch tip, so any build that runs — or retries — after its commit has been overtaken on `master` dies in the artifact-load init container with `failed to get resolve revision: reference not found`, before Docker ever starts. It first surfaced on delayed image builds, but the same pattern is in every CI sensor.

### Changes

- `charts/chorus-ci` (0.0.148 → 0.0.149)
  - Remove `depth: 1` from every git artifact across the CI sensors (`build-images`, `build-chorus-backend`, `build-services`, `build-web-ui`, `build-workbench-operator`) and the backend CI workflow template — 12 artifacts in all. The checkout is now full-history, so any pinned commit (tip *or* ancestor) resolves. The `ref` is kept.
  - Raising `depth` to a fixed N was rejected: it only postpones the same failure for a build delayed by more than N commits. A full clone of the source repos is negligible next to the multi-GB Docker build that follows (the largest, `images`, is ~176 MB / 373 commits).

### Effects

- `helm template charts/chorus-ci` renders 17 git artifacts: 0 with `depth:`, all retaining `ref`.
- No change for a build that runs while its commit is still the tip. The only behavioural change is that a delayed / retried / replayed build of an ancestor commit now resolves its revision instead of failing the init container.
- Side note: the currently-deployed 0.0.148 git artifacts are missing the `ref` field that is already committed on `master` under the same version — the template had been edited without a version bump, so it never rolled out. The 0.0.149 bump ships both that `ref` and this `depth` removal.

### Verification

- `helm lint charts/chorus-ci`: 0 failed.
- `helm template charts/chorus-ci`: renders; grep confirms 0 `depth:` lines and 17 `ref` artifacts.
- Reproduced live on an Argo Workflows cluster: two image builds that had failed at the artifact-load step were re-submitted with `depth` removed — both cleared the init container and proceeded into the Docker build.

### Versions

- chorus-ci 0.0.148 → 0.0.149