### PR TITLE
fix(harbor): cap core/exporter db connection pool defaults

### DIFF
--- a/charts/harbor/Chart.yaml
+++ b/charts/harbor/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: An open source trusted cloud native registry that stores, signs, and scans content.
 name: harbor
-version: 0.0.9
+version: 0.0.10
 dependencies:
   - name: harbor
     version: 1.17.1

--- a/charts/harbor/values.yaml
+++ b/charts/harbor/values.yaml
@@ -82,6 +82,16 @@ harbor:
 
   database:
     type: external
+    # Connection pool sized for an EXTERNAL Postgres, not Harbor's bundled DB.
+    # The goharbor defaults (maxIdleConns=100, maxOpenConns=900) are applied PER POD
+    # to BOTH core and exporter — they assume the bundled DB (max_connections~1024)
+    # and will saturate a smaller external DB with idle connections.
+    # These values target a stock Postgres (max_connections=100). Keep this invariant
+    # true if you raise them or scale core/exporter replicas:
+    #   (core.replicas + exporter.replicas) * maxOpenConns + ~40 overhead < max_connections
+    # Envs with a larger, tuned DB may override maxOpenConns upward per environment.
+    maxIdleConns: 10
+    maxOpenConns: 30
     external:
       host: "chorus-local-harbor-db-postgresql"
       port: "5432"


### PR DESCRIPTION
## Cap Harbor core/exporter Postgres connection pool for external databases

Harbor's upstream chart ships connection-pool defaults sized for its *bundled* PostgreSQL (`max_connections ≈ 1024`). When Harbor runs against an external Postgres, those defaults oversubscribe it: `maxIdleConns: 100` / `maxOpenConns: 900` are applied **per pod to both `core` and `exporter`**, so the two pods alone hold up to ~200 idle connections steady-state and can open ~1800 — enough to saturate a stock external DB and produce `FATAL: sorry, too many clients already` (SQLSTATE 53300), with `core` then returning misleading 401s when it can't get a connection to validate auth.

This sets a sane default for the external-DB topology and documents the sizing invariant so the values are re-tuned correctly when scaling.

### Changes

- `harbor` chart (0.0.9 → 0.0.10)
  - `harbor.database.maxIdleConns` 100 → 10 and `harbor.database.maxOpenConns` 900 → 30. The goharbor subchart exposes a single pool knob applied to both `core` and `exporter`, so these are sized for a stock Postgres (`max_connections = 100`): worst-case open `2 × 30 + ~40 overhead ≈ 100`, steady-state idle ~20.
  - Added an invariant comment next to the values: `(core.replicas + exporter.replicas) * maxOpenConns + ~40 < max_connections`, and a note that environments with a larger, tuned DB may override `maxOpenConns` upward.

### Effects

- `helm template` now renders, by default, `POSTGRESQL_MAX_IDLE_CONNS`/`POSTGRESQL_MAX_OPEN_CONNS` (core) and `HARBOR_DATABASE_MAX_IDLE_CONNS`/`HARBOR_DATABASE_MAX_OPEN_CONNS` (exporter) as `10` / `30`.
- Steady-state idle connections from core+exporter drop from ~200 to ~20; worst-case open ≤ 60. No other rendered resources change.
- Deployments that already override `harbor.database.maxIdleConns` / `maxOpenConns` are unaffected.

### Verification

- `helm lint charts/harbor`: passes.
- `helm template charts/harbor` (default values): core and exporter ConfigMaps render `10` / `30`.

### Versions

- harbor chart 0.0.9 → 0.0.10
