### PR TITLE
chore(juicefs): bump operator + s3-gateway images to JuiceFS 1.3.1

### DIFF
--- a/charts/juicefs-operator/Chart.yaml
+++ b/charts/juicefs-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: juicefs-operator
 description: A Helm chart for JuiceFS Cache Group Operator
-version: 0.0.1
+version: 0.0.2
 dependencies:
   - name: juicefs-operator
     version: 0.8.1

--- a/charts/juicefs-operator/values.yaml
+++ b/charts/juicefs-operator/values.yaml
@@ -57,8 +57,8 @@ cronSync:
   # dump alongside the chunks.
   schedule: "0 4 * * *"
 
-  # juicefs sync image; matches the JuiceFS CSI driver image stream.
-  image: juicedata/juicefs:1.2.3
+  # juicefs sync image; matches the JuiceFS CSI driver image stream (csi-driver ceMountImage ce-v1.3.1).
+  image: juicedata/juicefs:1.3.1
 
   # juicefs sync options. --ignore-existing = true append-only: skip EVERY key
   # already on the replica (plain sync would still overwrite an existing key

--- a/charts/juicefs-s3-gateway/Chart.yaml
+++ b/charts/juicefs-s3-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: juicefs-s3-gateway
 description: A Helm chart for JuiceFS S3 Gateway.
-version: 0.0.6
+version: 0.0.7
 dependencies:
   - name: juicefs-s3-gateway
     version: 0.11.4

--- a/charts/juicefs-s3-gateway/values.yaml
+++ b/charts/juicefs-s3-gateway/values.yaml
@@ -8,7 +8,7 @@ juicefs-s3-gateway:
     # For JuiceFS Community Edition, use ce-vx.x.x style tags
     # For JuiceFS Enterprise Edition, use ee-vx.x.x style tags
     # Find the latest built images in our docker image repo: https://hub.docker.com/r/juicedata/mount
-    tag: "ce-v1.2.3"
+    tag: "ce-v1.3.1"
 
   secret:
     enabled: false


### PR DESCRIPTION
## Bump JuiceFS chart images to 1.3.1

Aligns the JuiceFS chart images with the version the CSI driver already runs (`mount:ce-v1.3.1`); the operator sync image was stale at 1.2.3 (which also surfaced a flaky pull during testing).

- `juicefs-operator` (`0.0.1 → 0.0.2`): CronSync sync image `juicedata/juicefs:1.2.3 → 1.3.1`.
- `juicefs-s3-gateway` (`0.0.6 → 0.0.7`): mount image tag `ce-v1.2.3 → ce-v1.3.1`.

`helm lint` clean on both charts.
