### PR TITLE
feat(juicefs-operator): optional imagePullSecrets on sync pods (0.0.3)

### DIFF
--- a/charts/juicefs-operator/Chart.yaml
+++ b/charts/juicefs-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: juicefs-operator
 description: A Helm chart for JuiceFS Cache Group Operator
-version: 0.0.2
+version: 0.0.3
 dependencies:
   - name: juicefs-operator
     version: 0.8.1

--- a/charts/juicefs-operator/templates/cronsync.yaml
+++ b/charts/juicefs-operator/templates/cronsync.yaml
@@ -15,6 +15,10 @@ spec:
   syncTemplate:
     spec:
       image: {{ .Values.cronSync.image | quote }}
+      {{- with .Values.cronSync.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       # Single sync pod on purpose. The egress CNP/NetworkPolicy allows only DNS
       # + S3; raising this introduces manager↔worker pod-to-pod traffic that the
       # policy would silently drop. If you ever need >1 for throughput, also add

--- a/charts/juicefs-operator/values.yaml
+++ b/charts/juicefs-operator/values.yaml
@@ -60,6 +60,9 @@ cronSync:
   # juicefs sync image; matches the JuiceFS CSI driver image stream (csi-driver ceMountImage ce-v1.3.1).
   image: juicedata/juicefs:1.3.1
 
+  # Optional pull secrets for the sync pods.
+  imagePullSecrets: []
+
   # juicefs sync options. --ignore-existing = true append-only: skip EVERY key
   # already on the replica (plain sync would still overwrite an existing key
   # when the source size differs — see the block comment above). Safe for a


### PR DESCRIPTION
## Optional imagePullSecrets for the sync pods

Adds an optional `cronSync.imagePullSecrets` value, rendered into the CronSync sync pod template only when set (`{{- with }}`). The default is empty, so existing installs are unchanged; environments that pull the sync image from an authenticated registry can set it.

juicefs-operator `0.0.2 → 0.0.3`. `helm lint` clean; verified it renders with and without the value.
