### PR TITLE
fix(juicefs-operator): default sync image to juicedata/mount

### DIFF
--- a/charts/juicefs-operator/Chart.yaml
+++ b/charts/juicefs-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: juicefs-operator
 description: A Helm chart for JuiceFS Cache Group Operator
-version: 0.0.4
+version: 0.0.5
 dependencies:
   - name: juicefs-operator
     version: 0.8.1

--- a/charts/juicefs-operator/README.md
+++ b/charts/juicefs-operator/README.md
@@ -35,7 +35,7 @@ copying the **whole source bucket (chunks + `meta/` dumps)** to a dedicated **re
 cronSync:
   enabled: true
   schedule: "0 4 * * *"            # daily; align after the metadata auto-backup window
-  image: juicedata/juicefs:1.3.1   # any image carrying the juicefs binary (incl. `sync`)
+  image: juicedata/mount:ce-v1.3.1 # juicedata/mount — carries the juicefs binary incl. `sync`
   imagePullSecrets: []             # e.g. [{name: <pull-secret>}] when pulling from a private/proxy registry
   source:
     host: <s3-endpoint>            # e.g. s3.example.com (no scheme)
@@ -51,6 +51,9 @@ chorusNetworkPolicy:
 ```
 
 The sync URI is built path-style as `s3://<host>/<bucket>` for both source and replica.
+
+> **Image:** use `juicedata/mount` (it ships the `juicefs` binary, including `sync`), not
+> `juicedata/juicefs` — the latter is a Docker *volume plugin*, not a container image.
 
 ## Mandatory Secrets
 
@@ -100,7 +103,7 @@ create the pull secret in the namespace and reference it:
 
 ```yaml
 cronSync:
-  image: <registry>/juicedata/juicefs:1.3.1
+  image: <registry>/juicedata/mount:ce-v1.3.1
   imagePullSecrets:
     - name: <pull-secret>
 ```

--- a/charts/juicefs-operator/values.yaml
+++ b/charts/juicefs-operator/values.yaml
@@ -57,8 +57,10 @@ cronSync:
   # dump alongside the chunks.
   schedule: "0 4 * * *"
 
-  # juicefs sync image; matches the JuiceFS CSI driver image stream (csi-driver ceMountImage ce-v1.3.1).
-  image: juicedata/juicefs:1.3.1
+  # juicefs sync image: juicedata/mount ships the juicefs binary (incl. sync), same stream as the
+  # CSI driver's ceMountImage. Not juicedata/juicefs — that's a Docker volume plugin, not a
+  # container image.
+  image: juicedata/mount:ce-v1.3.1
 
   # Optional pull secrets for the sync pods.
   imagePullSecrets: []


### PR DESCRIPTION
The chart defaulted cronSync.image to juicedata/juicefs:1.3.1, which is a Docker volume plugin (not a container image), so a sync pod on the default can never run. Change the default to juicedata/mount:ce-v1.3.1 (ships the juicefs binary incl. sync, same stream as the CSI driver ceMountImage), and fix the README examples + add a one-line note.

Chart 0.0.4 -> 0.0.5. helm lint clean.