### PR TITLE
fix(chorus-deploy): add option to override image tag

### DIFF
--- a/charts/argo-deploy/Chart.yaml
+++ b/charts/argo-deploy/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.15
+version: 0.0.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/argo-deploy/templates/chorus-application.yaml
+++ b/charts/argo-deploy/templates/chorus-application.yaml
@@ -26,6 +26,10 @@ spec:
       parameters:
         - name: podLabels.commit-sha
           value: $ARGOCD_APP_REVISION_SHORT
+      {{- with .imageTagOverride }}
+        - name: image.tag
+          value: {{ . | quote }}
+      {{- end }}
   - ref: values
     repoURL: {{ .repoURL | quote }}
     targetRevision: {{ .revision | default "HEAD" | quote }}


### PR DESCRIPTION
## Add opt-in image tag override for rolling-release Applications

Rolling-release Applications currently apply whatever `image.tag` their values file declares — if that's a mutable tag like `latest`, a pod only picks up new image content the next time it happens to restart for some other reason, not necessarily right after a new image is pushed. This adds an opt-in way to pin the tag to the exact git revision ArgoCD is syncing instead.

### Changes

- `charts/argo-deploy/templates/chorus-application.yaml` — added an optional `image.tag` Helm parameter, rendered only when a `rollingRelease` entry sets `imageTagOverride`. Uses ArgoCD's `$ARGOCD_APP_REVISION_SHORT` build-environment variable, so the value tracks whatever revision the Application is actually synced to.

### Effects

- No behavior change for any `rollingRelease` entry that doesn't set `imageTagOverride` — the parameter block only renders when the field is present.
- Entries that do set it get `image.tag` forced to match the resolved revision on every sync (including self-heal), instead of trusting a static/moving tag from the values file.

### Verification

- `helm lint` passes
- `helm template` against a representative values file (one entry with `imageTagOverride` set, one without) confirms: the entry with it gets a correctly-nested `image.tag` parameter; the entry without it renders with no trace of it — no stray whitespace or broken YAML in either branch

### Versions

- `argo-deploy` chart: 0.0.15 → 0.0.16
