### PR TITLE
feat(chorus-ci): remove tag latest

### DIFF
--- a/charts/chorus-ci/Chart.yaml
+++ b/charts/chorus-ci/Chart.yaml
@@ -18,4 +18,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.151
+version: 0.0.152

--- a/charts/chorus-ci/templates/build-chorus-backend-sensor.yaml
+++ b/charts/chorus-ci/templates/build-chorus-backend-sensor.yaml
@@ -354,8 +354,6 @@ spec:
                                 value: {{ .Values.sensor.registry | quote }}
                               - name: dockerConfigSecret
                                 value: {{ .Values.sensor.dockerConfig.secretName | quote }}
-                              - name: addLatestTag
-                                value: "true"
                             artifacts:
                               - name: source
                                 git:


### PR DESCRIPTION
the backend rolling deployment does not use the tag latest anymore