### PR TITLE
feat(chorus-ci): update chorus datastore host override for ci-backend

### DIFF
--- a/charts/chorus-ci/Chart.yaml
+++ b/charts/chorus-ci/Chart.yaml
@@ -18,4 +18,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.152
+version: 0.0.153

--- a/charts/chorus-ci/templates/backend-acceptance-tests-template.yaml
+++ b/charts/chorus-ci/templates/backend-acceptance-tests-template.yaml
@@ -14,9 +14,6 @@ spec:
     parameters:
     - name: releaseName
     - name: chorusBackendAcceptanceNamespace
-    - name: githubSecretName
-    - name: githubSecretUsernameKey
-    - name: githubSecretPasswordKey
     - name: chorusBackendImageTag
 
   serviceAccountName: {{ include "chorus-ci.serviceAccountName" . }}
@@ -26,9 +23,6 @@ spec:
       parameters:
       - name: releaseName
       - name: chorusBackendAcceptanceNamespace
-      - name: githubSecretName
-      - name: githubSecretUsernameKey
-      - name: githubSecretPasswordKey
       - name: chorusBackendImageTag
       artifacts:
         - name: source
@@ -64,12 +58,6 @@ spec:
         template: run-tests
         arguments:
           parameters:
-          - name: githubSecretName
-            value: "{{`{{inputs.parameters.githubSecretName}}`}}"
-          - name: githubSecretUsernameKey
-            value: "{{`{{inputs.parameters.githubSecretUsernameKey}}`}}"
-          - name: githubSecretPasswordKey
-            value: "{{`{{inputs.parameters.githubSecretPasswordKey}}`}}"
           - name: configContent
             value: "{{`{{steps.fetch-config.outputs.parameters.configContent}}`}}"
             # Workaround to pass file content between steps
@@ -200,9 +188,6 @@ spec:
     inputs:
       parameters:
       - name: configContent
-      - name: githubSecretName
-      - name: githubSecretUsernameKey
-      - name: githubSecretPasswordKey
       - name: chorusBackendAcceptanceNamespace
       - name: releaseName
       artifacts:
@@ -253,24 +238,18 @@ spec:
       image: {{ .Values.chorusBackend.golang.imageDomain | default .Values.global.imageDomain }}/{{ .Values.chorusBackend.golang.imageNamespace | default .Values.global.imageNamespace }}/golang:{{ .Values.chorusBackend.golang.tag | default "latest" }}
       # TODO: investigate configuring resources for this step (currently takes ~5min to complete)
       env:
-      - name: GIT_USERNAME
-        valueFrom:
-          secretKeyRef:
-            name: "{{`{{inputs.parameters.githubSecretName}}`}}"
-            key: "{{`{{inputs.parameters.githubSecretUsernameKey}}`}}"
-      - name: GIT_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: "{{`{{inputs.parameters.githubSecretName}}`}}"
-            key: "{{`{{inputs.parameters.githubSecretPasswordKey}}`}}"
       - name: CONFIG_CONTENT
         value: "{{`{{inputs.parameters.configContent}}`}}"
       - name: TEST_CONFIG_FILE
         value: "/src/config.yaml"
+      # DB_HOST will be removed in the near future
+      # as the host will be set via TEST_CONFIG_SET instead
       - name: DB_HOST
         value: "localhost"
+      - name: TEST_CONFIG_SET
+        value: "storage.datastores.chorus.host=localhost"
       # TODO: discuss leveraging kubernetes DNS directly instead of port-forwarding
-      # we can already set the DB_HOST to service_name.namespace.svc.cluster.local
+      # we can already set the storage.datastores.chorus.host to service_name.namespace.svc.cluster.local
       # but we also need to add this feature for the backend service
       # see tests/helpers/config.go in the chorus-backend repo
       command: [sh, -e, -c]
@@ -287,10 +266,6 @@ spec:
             echo ""
           fi
 
-          export GOPRIVATE=github.com/CHORUS-TRE/*
-          export GIT_CONFIG_COUNT=1
-          export GIT_CONFIG_KEY_0=url."https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/".insteadOf
-          export GIT_CONFIG_VALUE_0=https://github.com/
           go mod download
           go test -v -p 1 -timeout 15m --tags acceptance ./tests/acceptance/...
       workingDir: "/src"

--- a/charts/chorus-ci/templates/chorus-backend-ci-workflow-template.yaml
+++ b/charts/chorus-ci/templates/chorus-backend-ci-workflow-template.yaml
@@ -1,8 +1,5 @@
 {{- $fullName := include "chorus-ci.fullname" . -}}
 {{- $serviceAccountName := include "chorus-ci.serviceAccountName" . -}}
-{{- $githubSecretName := .Values.gitCredentials.secretName | default "argo-workflows-github-pat" }}
-{{- $githubSecretUsernameKey := .Values.gitCredentials.usernameKey | default "username" }}
-{{- $githubSecretPasswordKey := .Values.gitCredentials.passwordKey | default "password" }}
 {{- $backendAcceptanceTestsReleaseName := "acceptance" -}}
 ---
 apiVersion: argoproj.io/v1alpha1
@@ -63,12 +60,6 @@ spec:
             git:
               repo: "{{`{{workflow.parameters.repoUrl}}`}}"
               revision: "{{`{{workflow.parameters.sha}}`}}"
-              usernameSecret:
-                name: {{ $githubSecretName }}
-                key: {{ $githubSecretUsernameKey }}
-              passwordSecret:
-                name: {{ $githubSecretName }}
-                key: {{ $githubSecretPasswordKey }}
               ref: "{{`{{workflow.parameters.ref}}`}}"
       container:
         image: {{ .Values.chorusBackend.golang.imageDomain | default .Values.global.imageDomain }}/{{ .Values.chorusBackend.golang.imageNamespace | default .Values.global.imageNamespace }}/golang:{{ .Values.chorusBackend.golang.tag | default "latest" }}
@@ -106,12 +97,6 @@ spec:
                   git:
                     repo: "{{`{{workflow.parameters.repoUrl}}`}}"
                     revision: "{{`{{workflow.parameters.sha}}`}}"
-                    usernameSecret:
-                      name: {{ $githubSecretName }}
-                      key: {{ $githubSecretUsernameKey }}
-                    passwordSecret:
-                      name: {{ $githubSecretName }}
-                      key: {{ $githubSecretPasswordKey }}
                     ref: "{{`{{workflow.parameters.ref}}`}}"
         - - name: backend-acceptance-tests
             templateRef:
@@ -130,12 +115,6 @@ spec:
                       value: "{{ $backendAcceptanceTestsReleaseName }}-{{`{{=sprig.trunc(8, workflow.uid)}}`}}"
             arguments:
               parameters:
-                - name: githubSecretName
-                  value: {{ $githubSecretName }}
-                - name: githubSecretUsernameKey
-                  value: {{ $githubSecretUsernameKey }}
-                - name: githubSecretPasswordKey
-                  value: {{ $githubSecretPasswordKey }}
                 - name: releaseName
                   value: "{{ $backendAcceptanceTestsReleaseName }}-{{`{{=sprig.trunc(8, workflow.uid)}}`}}"
                 - name: chorusBackendAcceptanceNamespace
@@ -147,10 +126,4 @@ spec:
                   git:
                     repo: "{{`{{workflow.parameters.repoUrl}}`}}"
                     revision: "{{`{{workflow.parameters.sha}}`}}"
-                    usernameSecret:
-                      name: {{ $githubSecretName }}
-                      key: {{ $githubSecretUsernameKey }}
-                    passwordSecret:
-                      name: {{ $githubSecretName }}
-                      key: {{ $githubSecretPasswordKey }}
                     ref: "{{`{{workflow.parameters.ref}}`}}"


### PR DESCRIPTION
follows : https://github.com/CHORUS-TRE/chorus-backend/pull/296
the DB_HOST env var is now obsolete (left only for smooth transition, will be removed completely)