### PR TITLE
fix(chorus-gateway): source-restrict the ACME HTTP-01 solver port in the CNP

### DIFF
--- a/charts/chorus-gateway/Chart.yaml
+++ b/charts/chorus-gateway/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: chorus-gateway
 description: Envoy Gateway routes and SecurityPolicies for CHORUS services
-version: 0.0.23
+version: 0.0.24
 maintainers:
   - name: iDmple
     email: nathalie.casati@chuv.ch

--- a/charts/chorus-gateway/templates/ciliumnetworkpolicy.yaml
+++ b/charts/chorus-gateway/templates/ciliumnetworkpolicy.yaml
@@ -45,18 +45,32 @@ spec:
     # from anywhere. Allowed sources: in-cluster (cert-manager's HTTP-01 self-check) plus the
     # ACME validator networks in httpSolverAllowedCIDRs. Empty allowlist = self-check only;
     # the external ACME server cannot validate until its CIDR is added (fail-closed).
+    #
+    # Two SEPARATE rules on purpose: Cilium rejects fromEntities and fromCIDR in the SAME
+    # ingress rule (the L3 source types are mutually exclusive per rule). Rules in the
+    # ingress list are OR'ed across rules, so the two together admit cluster OR the CIDRs.
+    #
+    # The fromCIDR leg only restricts anything where client source IPs reach the Envoy pods
+    # UNREWRITTEN (envoyService externalTrafficPolicy: Local). Under SNAT (Cluster), the
+    # validator arrives as a node IP, which carries a cluster identity — so the fromEntities
+    # rule would admit it and the allowlist is inert. Keep the gateway on Local for this to
+    # be meaningful.
     - fromEntities:
         - cluster
-      {{- with .Values.httpSolverAllowedCIDRs }}
-      fromCIDR:
-        {{- range . }}
-        - {{ . | quote }}
-        {{- end }}
-      {{- end }}
       toPorts:
         - ports:
             - port: "10080"
               protocol: TCP
+    {{- with .Values.httpSolverAllowedCIDRs }}
+    - fromCIDR:
+        {{- range . }}
+        - {{ . | quote }}
+        {{- end }}
+      toPorts:
+        - ports:
+            - port: "10080"
+              protocol: TCP
+    {{- end }}
     {{- end }}
 {{- end }}
 

--- a/charts/chorus-gateway/templates/ciliumnetworkpolicy.yaml
+++ b/charts/chorus-gateway/templates/ciliumnetworkpolicy.yaml
@@ -1,10 +1,16 @@
-{{- if or .Values.internalRoutes .Values.externalRoutes .Values.openRoutes .Values.internalShellServices }}
+{{- if or .Values.internalRoutes .Values.externalRoutes .Values.openRoutes .Values.internalShellServices .Values.httpSolverListener }}
 ---
-# Allow ingress on the Envoy Gateway pods from both cluster and external traffic.
-# Access control is enforced per-route via SecurityPolicy (internal: allow podCIDR,
-# external: deny podCIDR, open: no restriction).
+# Allow ingress on the Envoy Gateway pods.
 # Adding any ingress rule triggers Cilium deny-by-default for ALL other ingress on the
 # matched pods, so every Envoy listener port must be explicitly listed here.
+#
+# HARDENING RULE — do NOT add a port to the "from anywhere" toPorts block below unless a
+# per-route Envoy SecurityPolicy governs who may use that port's route (internal routes
+# allow podCIDR, external deny podCIDR, open none; shell TCPRoutes carry a podCIDR
+# SecurityPolicy). That L7 SecurityPolicy is what makes a from-anywhere L3/L4 admission
+# acceptable. A listener whose route has NO SecurityPolicy we control — e.g. cert-manager's
+# ACME HTTP-01 solver, whose HTTPRoute cert-manager owns — MUST NOT be added to the open
+# block; it has to be source-restricted at L3/L4 like the httpSolverListener rule below.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -17,6 +23,9 @@ spec:
     matchLabels:
       app.kubernetes.io/managed-by: envoy-gateway
   ingress:
+    {{- if or .Values.internalRoutes .Values.externalRoutes .Values.openRoutes .Values.internalShellServices }}
+    # From anywhere (cluster + external): every route on these ports is filtered per-route
+    # by a SecurityPolicy (internal: allow podCIDR, external: deny podCIDR, open: none).
     - toPorts:
         - ports:
             {{- if or .Values.internalRoutes .Values.externalRoutes .Values.openRoutes }}
@@ -28,12 +37,27 @@ spec:
             - port: {{ add .gatewayPort 10000 | toString | quote }}
               protocol: TCP
             {{- end }}
-            {{- if .Values.httpSolverListener }}
-            # ACME HTTP-01 solver listener (gateway-helm httpSolverListener):
-            # gateway port 80 → Envoy remaps to 10080.
+    {{- end }}
+    {{- if .Values.httpSolverListener }}
+    # ACME HTTP-01 solver listener (gateway-helm httpSolverListener): gateway port 80 →
+    # Envoy remaps to 10080. cert-manager owns the challenge HTTPRoute, so there is NO
+    # per-route SecurityPolicy to filter it — access is SOURCE-RESTRICTED here, never opened
+    # from anywhere. Allowed sources: in-cluster (cert-manager's HTTP-01 self-check) plus the
+    # ACME validator networks in httpSolverAllowedCIDRs. Empty allowlist = self-check only;
+    # the external ACME server cannot validate until its CIDR is added (fail-closed).
+    - fromEntities:
+        - cluster
+      {{- with .Values.httpSolverAllowedCIDRs }}
+      fromCIDR:
+        {{- range . }}
+        - {{ . | quote }}
+        {{- end }}
+      {{- end }}
+      toPorts:
+        - ports:
             - port: "10080"
               protocol: TCP
-            {{- end }}
+    {{- end }}
 {{- end }}
 
 {{- range .Values.internalShellServices }}

--- a/charts/chorus-gateway/values.yaml
+++ b/charts/chorus-gateway/values.yaml
@@ -276,5 +276,14 @@ internalShellServices: []
 # two flags together. That listener serves cert-manager's ACME HTTP-01 challenges on
 # gateway port 80 (Envoy remaps it to 10080), and every Envoy listener port must be
 # listed in the envoy-gateway-ingress CNP or deny-by-default drops the challenge
-# traffic and HTTP-01 validation never completes.
+# traffic and HTTP-01 validation never completes. The 10080 port is NOT opened from
+# anywhere — it is source-restricted via httpSolverAllowedCIDRs below.
 httpSolverListener: false
+
+# Source CIDRs allowed to reach the ACME HTTP-01 solver port (10080), IN ADDITION to
+# in-cluster traffic (cert-manager's self-check, always allowed). cert-manager owns the
+# solver HTTPRoute so it has no per-route SecurityPolicy; the port is restricted here at
+# L3/L4 instead of opened from anywhere. Set this to the ACME server's validation source
+# network(s); leave empty and external HTTP-01 validation cannot complete (fail-closed).
+# Only used when httpSolverListener is true.
+httpSolverAllowedCIDRs: []

--- a/charts/chorus-gateway/values.yaml
+++ b/charts/chorus-gateway/values.yaml
@@ -286,4 +286,10 @@ httpSolverListener: false
 # L3/L4 instead of opened from anywhere. Set this to the ACME server's validation source
 # network(s); leave empty and external HTTP-01 validation cannot complete (fail-closed).
 # Only used when httpSolverListener is true.
+#
+# Only meaningful when the gateway preserves client source IPs (envoyService
+# externalTrafficPolicy: Local). Under SNAT the validator arrives with a node IP / cluster
+# identity, which the always-on cluster rule already admits — the allowlist can't
+# distinguish it, and a node CIDR cannot be allowlisted (Cilium CIDR rules never match
+# cluster/host-originated traffic).
 httpSolverAllowedCIDRs: []

--- a/ci/test-values/chorus-gateway.yaml
+++ b/ci/test-values/chorus-gateway.yaml
@@ -9,7 +9,8 @@
 # behind having at least one route. Enable one internalRoute (and podCIDR, which
 # its SecurityPolicy requires) so the CNP, HTTPRoute, SecurityPolicy and
 # ReferenceGrant all render and get admission-checked. httpSolverListener: true
-# additionally emits the ACME HTTP-01 solver port (10080) in the CNP.
+# additionally emits the source-restricted ACME HTTP-01 solver port (10080) in the
+# CNP; httpSolverAllowedCIDRs exercises its fromCIDR allowlist branch.
 #
 # The referenced Service/Gateway need not exist — these are unreconciled CRs;
 # the chart ships no workload, so helm --wait returns as soon as they apply.
@@ -19,6 +20,9 @@ gateway:
 podCIDR: 10.0.0.0/16
 
 httpSolverListener: true
+
+httpSolverAllowedCIDRs:
+  - 192.0.2.0/24
 
 internalRoutes:
   - name: smoke


### PR DESCRIPTION
## Source-restrict the ACME HTTP-01 solver port on the gateway CNP

#804 admits the ACME HTTP-01 solver listener port (gateway 80 → Envoy 10080) in the `envoy-gateway-ingress` CiliumNetworkPolicy, but adds it to the **from-anywhere** `toPorts` block — so any source that can reach the gateway can connect to `:10080`. The solver's HTTPRoute is owned by cert-manager, so unlike our own routes it has no per-route SecurityPolicy governing who may use it. That leaves the flat L3/L4 admission as the only access control, and it restricts nothing.

This hardens it: `10080` moves out of the from-anywhere block into its own **source-restricted** admission — `fromEntities: cluster` (cert-manager's in-cluster HTTP-01 self-check) plus an explicit `fromCIDR` allowlist for the external ACME validator, via a new `httpSolverAllowedCIDRs` value. An empty allowlist is **fail-closed**: self-check only, external validation cannot complete until the validator's CIDR is added.

Cilium rejects `fromEntities` and `fromCIDR` in the same ingress rule (the L3 source types are mutually exclusive per rule), so the two are rendered as **separate** ingress rules on 10080 — rules in the list are OR'ed across rules, giving the intended union while each passes agent validation.

It also adds a hardening-rule comment to the CNP: a port may only go in the from-anywhere block when a per-route SecurityPolicy governs its route; a listener with no controllable SecurityPolicy (like the ACME solver) must be source-restricted at L3/L4, never added to the open block.

`chorus-gateway` 0.0.23 → 0.0.24. `helm lint` clean; rendered CNP verified for solver+allowlist (two valid rules), solver+empty-allowlist (fail-closed), and non-solver (identical to 0.0.23) cases.

### Requires `externalTrafficPolicy: Local` on the gateway service

The `fromCIDR` allowlist only restricts anything where client source IPs reach the Envoy pods **unrewritten** — i.e. the gateway's `envoyService.externalTrafficPolicy` is `Local`. Under SNAT (`Cluster`), the validator arrives as a **node IP**, which carries a `cluster` identity: the always-on `fromEntities: cluster` rule then admits it, the allowlist is inert (effectively open, not fail-closed), and you cannot fix that by allowlisting the node CIDR — Cilium CIDR rules never match cluster/host-originated traffic. Keep the gateway on `Local` (already required for the podCIDR SecurityPolicy on the other routes) for this restriction to be meaningful.

### Setting `httpSolverAllowedCIDRs`

The value is the **source network the ACME server validates from** (its egress address as seen at the gateway), not the address cert-manager connects to. In-cluster self-check is already covered by `fromEntities: cluster`, so the allowlist only needs the external validator.

With the gateway on `Local`, find it with Hubble by watching what gets dropped on the solver port while a certificate is issuing:

```
hubble observe --namespace envoy-gateway-system --port 10080 --verdict DROPPED --follow
```

The source IP on the dropped flows is the value to allowlist. Then set it in the env values:

```
httpSolverAllowedCIDRs:
  - <observed-source>/32
```

Pairs with #804 (gateway-helm `httpSolverListener`).
